### PR TITLE
update task dependencies to be more specific 

### DIFF
--- a/jbrowse/build.gradle
+++ b/jbrowse/build.gradle
@@ -65,5 +65,5 @@ project.tasks.copyJBrowse.mustRunAfter("npmRunBuild")
 project.tasks.copyJBrowse.mustRunAfter("npmRunBuildProd")
 
 project.tasks.copyJBrowseCss.dependsOn(project.tasks.copyJBrowse)
-project.tasks.module.dependsOn(project.tasks.copyJBrowse)
-project.tasks.module.dependsOn(project.tasks.copyJBrowseCss)
+project.tasks.processModuleResources.dependsOn(project.tasks.copyJBrowse)
+project.tasks.processModuleResources.dependsOn(project.tasks.copyJBrowseCss)


### PR DESCRIPTION
so we are assured the jbrowse resources are copied into the resources directory before this directory is copied to the build directory