### PR TITLE
Secure Issue 39741: LDAP Sync SSL protocol configuration setting is not set correctly

### DIFF
--- a/OpenLdapSync/resources/credits/jars.txt
+++ b/OpenLdapSync/resources/credits/jars.txt
@@ -1,4 +1,4 @@
 {table}
 Filename|Component|Version|Source|License|LabKey Dev|Purpose
-api-all-1.0.2.jar|Apache LDAP API|1.0.2|{link:Apache Directory|http://directory.apache.org/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|bbimber|Used by LDAP Sync
+api-all-1.0.3.jar|Apache LDAP API|1.0.3|{link:Apache Directory|http://directory.apache.org/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|bbimber|Used by LDAP Sync
 {table}


### PR DESCRIPTION
- Bump ApacheDirectory to 1.0.3 in jars.txt

Pending SVN check-in and Triage approval.
https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=39741