### PR TITLE
Remove dependencies.txt file

### DIFF
--- a/OpenLdapSync/resources/credits/dependencies.txt
+++ b/OpenLdapSync/resources/credits/dependencies.txt
@@ -1,2 +1,0 @@
-# direct external dependencies for project :server:modules:DiscvrLabKeyModules:OpenLdapSync
-api-all-1.0.2.jar


### PR DESCRIPTION
This file is generated by the build and not meant to be checked in (it is currently out of date)