### PR TITLE
Add dependency on htsjdk library in modules the rely on it directly.

### DIFF
--- a/jbrowse/build.gradle
+++ b/jbrowse/build.gradle
@@ -8,6 +8,7 @@ repositories {
 }
 
 dependencies {
+    implementation "com.github.samtools:htsjdk:${htsjdkVersion}"
 	BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
 	BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:DiscvrLabKeyModules:SequenceAnalysis", depProjectConfig: "apiJarFile")
 	BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:DiscvrLabKeyModules:SequenceAnalysis", depProjectConfig: "apiElements")


### PR DESCRIPTION
#### Rationale
In preparation for Gradle 7.0, we have slowly been updating dependencies that rely on the `compile` configuration (which has been deprecated for this use and will result in an error in Gradle 7.0).  This configuration leaks dependencies out of a project so other projects have not had to explicitly declare dependencies that came through `compile` transitively.  With a future gradlePlugins release, we'll remove the extension of the `compile` dependency from the `external` dependency, so this leakage will be stopped.

#### Related Pull Requests
* #42 

#### Changes
* Add an explicit dependency on htsjdk for the jbrowse module
