### PR TITLE
Declare api and implementation dependencies to align with code usages

### DIFF
--- a/SequenceAnalysis/build.gradle
+++ b/SequenceAnalysis/build.gradle
@@ -31,6 +31,7 @@ dependencies {
       exclude group: "org.apache.commons", module: "commons-collections4"
    }
 
+   external "commons-net:commons-net:${commonsNetVersion}"
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:laboratory", depProjectConfig: "published", depExtension: "module")
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "published", depExtension: "module")
 }

--- a/SequenceAnalysis/build.gradle
+++ b/SequenceAnalysis/build.gradle
@@ -32,6 +32,8 @@ dependencies {
    }
 
    external "commons-net:commons-net:${commonsNetVersion}"
+   apiImplementation "org.apache.commons:commons-math3:${commonsMath3Version}"
+   external "org.apache.commons:commons-math3:${commonsMath3Version}"
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:laboratory", depProjectConfig: "published", depExtension: "module")
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "published", depExtension: "module")
 }

--- a/SequenceAnalysis/resources/credits/dependencies.txt
+++ b/SequenceAnalysis/resources/credits/dependencies.txt
@@ -6,3 +6,4 @@ bzip2-0.9.1.jar
 sam-1.96.jar
 commons-math3-3.6.1.jar
 picard-2.22.4.jar
+commons-net-3.5.jar

--- a/SequenceAnalysis/resources/credits/jars.txt
+++ b/SequenceAnalysis/resources/credits/jars.txt
@@ -5,6 +5,7 @@ sam-1.96.jar|picard tools|1.96|{link:picard tools|http://sourceforge.net/project
 biojava3-core-3.0.7.jar|biojava3-core|3.0.7|{link:biojava|http://biojava.org/wiki/Main_Page}|{link:GNU Lesser GPL V2.1|http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html}|bbimber|Java framework for processing biological data
 biojava3-genome-3.0.7.jar|biojava3-genome|3.0.7|{link:biojava|http://biojava.org/wiki/Main_Page}|{link:GNU Lesser GPL V2.1|http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html}|bbimber|Java framework for processing biological data
 commons-math3-3.6.1.jar|commons-math|3-3.6.1|{link:commons-math|http://commons.apache.org/proper/commons-math/}|{link:Apache License, Version 2.0|http://www.apache.org/licenses/LICENSE-2.0.txt}|bbimber|Self-contained mathematics and statistics components
+commons-net-3.5.jar|Commons Net|3.3|{link:Apache|http://jakarta.apache.org/commons/net/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|bbimber|FTPClient used to retrieve resources from other servers (e.g., GO annotations)
 htsjdk-2.21.3.jar|htsjdk|2.21.3|{link:htsjdk|http://samtools.github.io/htsjdk/}|{link:MIT License|http://opensource.org/licenses/MIT}|bbimber|Description	A Java API for high-throughput sequencing data (HTS) formats
 picard-2.22.4.jar|Picard Tools Lib|2.22.4|{link:PicardTools|https://github.com/broadinstitute/picard}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|bbimber|Manipulating Sequence Data
 {table}

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/FastqcRunner.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/FastqcRunner.java
@@ -359,7 +359,7 @@ public class FastqcRunner
         if (!samJar.exists())
             throw new RuntimeException("Not found: " + samJar.getPath());
 
-        File commonsMath = new File(apiLibDir, "commons-math3-3.6.1.jar");
+        File commonsMath = new File(libDir, "commons-math3-3.6.1.jar");
         if (!commonsMath.exists())
         {
             throw new RuntimeException("Not found: " + commonsMath.getPath());

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/FastqcRunner.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/FastqcRunner.java
@@ -349,7 +349,7 @@ public class FastqcRunner
         }
 
         File libDir = new File(ModuleLoader.getInstance().getModule(SequenceAnalysisModule.NAME).getExplodedPath(), "lib");
-        File apiLibDir = new File(ModuleLoader.getInstance().getModule("api").getExplodedPath(), "lib");
+        File coreLibDir = new File(ModuleLoader.getInstance().getModule("core").getExplodedPath(), "lib");
         File fastqcDir = new File(libDir.getParentFile(), "external/fastqc");
         File bzJar = new File(libDir, "bzip2-0.9.1.jar");
         if (!bzJar.exists())
@@ -359,7 +359,7 @@ public class FastqcRunner
         if (!samJar.exists())
             throw new RuntimeException("Not found: " + samJar.getPath());
 
-        File commonsMath = new File(libDir, "commons-math3-3.6.1.jar");
+        File commonsMath = new File(coreLibDir, "commons-math3-3.6.1.jar");
         if (!commonsMath.exists())
         {
             throw new RuntimeException("Not found: " + commonsMath.getPath());


### PR DESCRIPTION
#### Rationale
It is generally best practice to explicitly declare dependencies that are used in your code rather than relying on them to come through transitively.  Though in reality the risk of these transitive dependencies disappearing is low and would be easily noticed, the declaration of proper dependencies will assure that our published `pom` files are accurate and others will not have to separately declare some dependencies that we rely on when using our jar files.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1574

#### Changes
* Update dependencies and `jars.txt`
