### PR TITLE
update to runtimeElements dependency instead of apiElements to avoid problems with IntelliJ Gradle sync

### DIFF
--- a/jbrowse/build.gradle
+++ b/jbrowse/build.gradle
@@ -10,7 +10,7 @@ repositories {
 dependencies {
 	BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
 	BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:DiscvrLabKeyModules:SequenceAnalysis", depProjectConfig: "apiJarFile")
-	BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:DiscvrLabKeyModules:SequenceAnalysis", depProjectConfig: "apiElements")
+	BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:DiscvrLabKeyModules:SequenceAnalysis", depProjectConfig: "runtimeElements")
 	BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:laboratory", depProjectConfig: "apiJarFile")
 
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:laboratory", depProjectConfig: "published", depExtension: "module")


### PR DESCRIPTION
#### Rationale
The `apiElements` configuration is not consumable by other projects.  You need to use `runtimeElements` instead.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1611

#### Changes
* Update dependency declaration from jbrowse to SequenceAnalysis
