### PR TITLE
Update to a newer Omero version that's proxied in LabKey's Artifactory

### DIFF
--- a/omerointegration/build.gradle
+++ b/omerointegration/build.gradle
@@ -14,8 +14,73 @@ repositories {
 
 //excludes based on: https://github.com/glencoesoftware/omero-ms-core/blob/master/build.gradle
 dependencies {
-   external (group: 'org.openmicroscopy', name: 'omero-gateway', version: '5.6.3') 
-   
+   external (group: 'org.openmicroscopy', name: 'omero-gateway', version: '5.6.3')
+           {
+              exclude group: 'OME'
+              exclude group: 'antlr'
+              exclude group: 'asm'
+              exclude group: 'backport-util-concurrent'
+              exclude group: 'batik'
+              exclude group: 'cglib'
+              exclude group: 'ch.qos.logback', module: 'logback-classic'
+              // added to prevent excessively verbose global logging
+              exclude group: 'com.codahale.metrics'
+              exclude group: 'com.drewnoakes'
+              exclude group: 'com.esotericsoftware.kryo'
+              exclude group: 'com.google.guava'
+              exclude group: 'com.jamonapi'
+              exclude group: 'com.mortennobel'
+              exclude group: 'com.sun.activation', module: 'javax.activation'
+              exclude group: 'com.zeroc', module: 'freeze'
+              exclude group: 'com.zeroc', module: 'icefreeze'
+              exclude group: 'com.zeroc', module: 'icegrid'
+              exclude group: 'com.zeroc', module: 'icestorm'
+              exclude group: 'commons-beanutils'
+              exclude group: 'commons-codec'
+              exclude group: 'commons-collections'
+              exclude group: 'commons-io'
+              exclude group: 'commons-pool'
+              exclude group: 'dom4j'
+              exclude group: 'edu.ucar'
+              exclude group: 'freemarker'
+              exclude group: 'geronimo-spec'
+              exclude group: 'gnu.getopt'
+              exclude group: 'javassist'
+              exclude group: 'javax.jts'
+              exclude group: 'joda-time'
+              exclude group: 'net.sf.ehcache'
+              exclude group: 'ome', module: 'formats-gpl'
+              exclude group: 'ome', module: 'jai_imageio'
+              exclude group: 'ome', module: 'lwf-stubs'
+              exclude group: 'ome', module: 'turbojpeg'
+              exclude group: 'omero', module: 'dsl'
+              exclude group: 'omero', module: 'omero-shares'
+              exclude group: 'org.apache.lucene'
+              exclude group: 'org.apache.httpcomponents'
+              exclude group: 'org.codehaus.btm'
+              exclude group: 'org.hibernate'
+              exclude group: 'org.hibernate.javax.persistence'
+              exclude group: 'org.ini4j'
+              exclude group: "org.json", module: "json"
+              exclude group: 'org.postgresql'
+              exclude group: 'org.scijava'
+              exclude group: 'org.subethamail'
+              exclude group: 'pdfbox'
+              exclude group: 'quartz'
+              exclude group: 'xerces'
+              exclude group: 'xalan'
+              exclude group: 'xml-apis'
+              exclude group: 'zeroc', module: 'ice-db'
+
+              exclude group: 'org.springframework', module: 'spring-aop'
+              exclude group: 'org.springframework', module: 'spring-context'
+              exclude group: 'org.springframework', module: 'spring-expression'
+              exclude group: 'org.springframework', module: 'spring-core'
+              exclude group: 'org.springframework', module: 'spring-beans'
+              exclude group: 'org.springframework', module: 'spring-jdbc'
+              exclude group: 'org.springframework', module: 'spring-tx'
+           }
+
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
 
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "published", depExtension: "module")

--- a/omerointegration/build.gradle
+++ b/omerointegration/build.gradle
@@ -3,75 +3,20 @@ import org.labkey.gradle.util.BuildUtils;
 repositories {
    mavenLocal()
    mavenCentral()
+   maven {
+      url 'https://artifacts.openmicroscopy.org/artifactory/maven/'
+   }
+   maven {
+      url 'https://artifacts.glencoesoftware.com/artifactory/repo/'
+   }
 }
+
 
 //excludes based on: https://github.com/glencoesoftware/omero-ms-core/blob/master/build.gradle
 dependencies {
-   external (group: 'org.openmicroscopy', name: 'omero-gateway', version: '5.6.3') {
-      exclude group: 'OME'
-      exclude group: 'antlr'
-      exclude group: 'asm'
-      exclude group: 'backport-util-concurrent'
-      exclude group: 'batik'
-      exclude group: 'cglib'
-      exclude group: 'ch.qos.logback', module: 'logback-classic'  // added to prevent excessively verbose global logging
-      exclude group: 'com.codahale.metrics'
-      exclude group: 'com.drewnoakes'
-      exclude group: 'com.esotericsoftware.kryo'
-      exclude group: 'com.google.guava'
-      exclude group: 'com.jamonapi'
-      exclude group: 'com.mortennobel'
-      exclude group: 'com.zeroc', module: 'freeze'
-      exclude group: 'com.zeroc', module: 'icefreeze'
-      exclude group: 'com.zeroc', module: 'icegrid'
-      exclude group: 'com.zeroc', module: 'icestorm'
-      exclude group: 'commons-beanutils'
-      exclude group: 'commons-codec'
-      exclude group: 'commons-collections'
-      exclude group: 'commons-io'
-      exclude group: 'commons-pool'
-      exclude group: 'dom4j'
-      exclude group: 'edu.ucar'
-      exclude group: 'freemarker'
-      exclude group: 'geronimo-spec'
-      exclude group: 'gnu.getopt'
-      exclude group: 'javassist'
-      exclude group: 'javax.jts'
-      exclude group: 'joda-time'
-      exclude group: 'net.sf.ehcache'
-      exclude group: 'ome', module: 'formats-gpl'
-      exclude group: 'ome', module: 'jai_imageio'
-      exclude group: 'ome', module: 'lwf-stubs'
-      exclude group: 'ome', module: 'turbojpeg'
-      exclude group: 'omero', module: 'dsl'
-      exclude group: 'omero', module: 'omero-shares'
-      exclude group: 'org.apache.lucene'
-      exclude group: 'org.apache.httpcomponents'
-      exclude group: 'org.codehaus.btm'
-      exclude group: 'org.hibernate'
-      exclude group: 'org.hibernate.javax.persistence'
-      exclude group: 'org.ini4j'
-      exclude group: 'org.postgresql'
-      exclude group: 'org.scijava'
-      exclude group: 'org.subethamail'
-      exclude group: 'pdfbox'
-      exclude group: 'quartz'
-      exclude group: 'xerces'
-      exclude group: 'xalan'
-      exclude group: 'xml-apis'
-      exclude group: 'zeroc', module: 'ice-db'
+   external (group: 'org.openmicroscopy', name: 'omero-gateway', version: '5.6.3') 
+   
+   BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
 
-      exclude group: 'org.springframework', module: 'spring-aop'
-      exclude group: 'org.springframework', module: 'spring-context'
-      exclude group: 'org.springframework', module: 'spring-expression'
-      exclude group: 'org.springframework', module: 'spring-core'
-      exclude group: 'org.springframework', module: 'spring-beans'
-      exclude group: 'org.springframework', module: 'spring-jdbc'
-      exclude group: 'org.springframework', module: 'spring-tx'
-
-   }
-
-	BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
-
-	BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "published", depExtension: "module")
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "published", depExtension: "module")
 }

--- a/omerointegration/build.gradle
+++ b/omerointegration/build.gradle
@@ -7,8 +7,7 @@ repositories {
 
 //excludes based on: https://github.com/glencoesoftware/omero-ms-core/blob/master/build.gradle
 dependencies {
-   external (group: 'org.openmicroscopy', name: 'omero-gateway', version: '5.6.3')
-   external (group: 'org.openmicroscopy', name: 'omero-blitz', version: '5.5.6') {
+   external (group: 'org.openmicroscopy', name: 'omero-gateway', version: '5.6.3') {
       exclude group: 'OME'
       exclude group: 'antlr'
       exclude group: 'asm'

--- a/omerointegration/build.gradle
+++ b/omerointegration/build.gradle
@@ -3,14 +3,12 @@ import org.labkey.gradle.util.BuildUtils;
 repositories {
    mavenLocal()
    mavenCentral()
-   maven {
-      url 'https://artifacts.openmicroscopy.org/artifactory/maven/'
-   }
 }
 
 //excludes based on: https://github.com/glencoesoftware/omero-ms-core/blob/master/build.gradle
 dependencies {
-   external (group: 'omero', name: 'blitz', version: '5.5.0-m2-ice36-b103') {
+   external (group: 'org.openmicroscopy', name: 'omero-gateway', version: '5.6.3')
+   external (group: 'org.openmicroscopy', name: 'omero-blitz', version: '5.5.6') {
       exclude group: 'OME'
       exclude group: 'antlr'
       exclude group: 'asm'

--- a/omerointegration/resources/credits/dependencies.txt
+++ b/omerointegration/resources/credits/dependencies.txt
@@ -1,2 +1,2 @@
 # direct external dependencies for project :server:modules:DiscvrLabKeyModules:omerointegration
-blitz-5.5.0-m2-ice36-b103.jar
+omero-gateway-5.6.3.jar

--- a/omerointegration/resources/credits/jars.txt
+++ b/omerointegration/resources/credits/jars.txt
@@ -1,4 +1,4 @@
 {table}
 Filename|Component|Version|Source|License|LabKey Dev|Purpose
-blitz-5.5.0-m2-ice36-b103.jar|OMERO Client|5.5.0|{link:OMERO Client|https://www.openmicroscopy.org/site/support/omero5.2/developers/Java.html}|{link:GNU GPL, version 2|https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html}|bbimber|Used to interact with OMERO Servers
+omero-gateway-5.6.3.jar|OMERO Client|5.6.3|{link:OMERO Client|https://docs.openmicroscopy.org/omero/5.6.3/developers/Java.html}|{link:GNU GPL, version 2|https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html}|bbimber|Used to interact with OMERO Servers
 {table}


### PR DESCRIPTION
#### Rationale
openmicroscopy.org is down, so try a new Artifactory-based proxying and update to an official release version of Omero artifacts

#### Changes
* Remove third-party, currently offline Artifactory reference. Bump to newer point releases.