### PR TITLE
Use consistent versions for Commons Collections 4 and Google Protocol Buffers

### DIFF
--- a/omerointegration/build.gradle
+++ b/omerointegration/build.gradle
@@ -14,6 +14,9 @@ repositories {
 
 //excludes based on: https://github.com/glencoesoftware/omero-ms-core/blob/master/build.gradle
 dependencies {
+    external "com.google.protobuf:protobuf-java:${googleProtocolBufVersion}"
+    external("org.apache.commons:commons-collections4:${commonsCollections4Version}")
+
    external (group: 'org.openmicroscopy', name: 'omero-gateway', version: '5.6.3')
            {
               exclude group: 'OME'


### PR DESCRIPTION
#### Rationale
We don't want conflicting versions of libraries across modules.

https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_VerifyDependencies/1145949?

#### Related Pull Requests
* https://github.com/LabKey/DiscvrLabKeyModules/pull/65
* https://github.com/LabKey/server/pull/2
* https://github.com/LabKey/targetedms/pull/266

#### Changes
* Consolidate on Commons Collections 4.2 and Google Protocol Buffers 3.12.2