### PR TITLE
Update .gitignore to ignore .gradle file generated by the build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 # Created by npm install
 /jbrowse/jb_run.js
 /jbrowse/jb_setup.js
+/jbrowse/.gradle


### PR DESCRIPTION
#### Rationale
Git shouldn't care about .gradle

#### Changes
* update .gitignore
