### PR TITLE
Replace jcenter() with mavenCentral()

### DIFF
--- a/SequenceAnalysis/build.gradle
+++ b/SequenceAnalysis/build.gradle
@@ -8,7 +8,7 @@ import org.labkey.gradle.util.PropertiesUtils
 import java.util.regex.Matcher
 
 repositories {
-   jcenter()
+   mavenCentral()
    maven {
       url "https://clojars.org/repo"
    }

--- a/jbrowse/build.gradle
+++ b/jbrowse/build.gradle
@@ -1,7 +1,7 @@
 import org.labkey.gradle.util.BuildUtils;
 
 repositories {
-	jcenter()
+	mavenCentral()
 	maven {
 		url "https://clojars.org/repo"
 	}


### PR DESCRIPTION
#### Rationale
Jcenter is being sunsetting by Jfrog in May of this year and while the convenience method for Gradle will likely continue to work and Jcenter will continue to serve artifacts for some time, we might as well go ahead and update our build to use mavenCentral() instead.
