### PR TITLE
ColumnDecorator -> ColumnInfoTransformer

### DIFF
--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/query/SequenceAnalysisCustomizer.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/query/SequenceAnalysisCustomizer.java
@@ -12,6 +12,7 @@ import org.labkey.api.data.DataColumn;
 import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.JdbcType;
+import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.TableCustomizer;
@@ -99,21 +100,21 @@ public class SequenceAnalysisCustomizer implements TableCustomizer
     private enum COL_ENUM
     {
         refNtSequence(Integer.class, PageFlowUtil.set("sequenceid", "ref_nt_sequence")){
-            public void customizeColumn(BaseColumnInfo col, AbstractTableInfo ti)
+            public void customizeColumn(MutableColumnInfo col, AbstractTableInfo ti)
             {
                 col.setLabel("Ref NT Sequence");
                 addFk(ti.getUserSchema().getContainer(), ti.getUserSchema().getUser(), col, SequenceAnalysisSchema.SCHEMA_NAME, SequenceAnalysisSchema.TABLE_REF_NT_SEQUENCES, "rowid", "name");
             }
         },
         libraryId(Integer.class, PageFlowUtil.set("genomeId", "genome_id", "library_id")){
-            public void customizeColumn(BaseColumnInfo col, AbstractTableInfo ti)
+            public void customizeColumn(MutableColumnInfo col, AbstractTableInfo ti)
             {
                 col.setLabel("Reference Genome");
                 addFk(ti.getUserSchema().getContainer(), ti.getUserSchema().getUser(), col, SequenceAnalysisSchema.SCHEMA_NAME, SequenceAnalysisSchema.TABLE_REF_LIBRARIES, "rowid", "rowid");
             }
         },
         runid(Integer.class, PageFlowUtil.set("run_id")){
-            public void customizeColumn(BaseColumnInfo col, AbstractTableInfo ti)
+            public void customizeColumn(MutableColumnInfo col, AbstractTableInfo ti)
             {
                 col.setLabel("Run");
                 col.setShownInInsertView(false);
@@ -124,7 +125,7 @@ public class SequenceAnalysisCustomizer implements TableCustomizer
             }
         },
         jobid(Integer.class, PageFlowUtil.set("job_id")){
-            public void customizeColumn(BaseColumnInfo col, AbstractTableInfo ti)
+            public void customizeColumn(MutableColumnInfo col, AbstractTableInfo ti)
             {
                 col.setLabel("Job Id");
                 col.setShownInInsertView(false);
@@ -134,21 +135,21 @@ public class SequenceAnalysisCustomizer implements TableCustomizer
             }
         },
         dataId(Integer.class, PageFlowUtil.set("data_id")){
-            public void customizeColumn(BaseColumnInfo col, AbstractTableInfo ti)
+            public void customizeColumn(MutableColumnInfo col, AbstractTableInfo ti)
             {
                 col.setLabel("File Id");
                 addFk(ti.getUserSchema().getContainer(), ti.getUserSchema().getUser(), col, "exp", "data", "rowid", null);
             }
         },
         readset(Integer.class, PageFlowUtil.set("readsetId", "readset_id")){
-            public void customizeColumn(BaseColumnInfo col, AbstractTableInfo ti)
+            public void customizeColumn(MutableColumnInfo col, AbstractTableInfo ti)
             {
                 col.setLabel("Readset");
                 addFk(ti.getUserSchema().getContainer(), ti.getUserSchema().getUser(), col, SequenceAnalysisSchema.SCHEMA_NAME, SequenceAnalysisSchema.TABLE_READSETS, "rowid", null);
             }
         },
         analysisId(Integer.class, PageFlowUtil.set("analysis_id")){
-            public void customizeColumn(BaseColumnInfo col, AbstractTableInfo ti)
+            public void customizeColumn(MutableColumnInfo col, AbstractTableInfo ti)
             {
                 col.setLabel("Analysis Id");
                 addFk(ti.getUserSchema().getContainer(), ti.getUserSchema().getUser(), col, SequenceAnalysisSchema.SCHEMA_NAME, SequenceAnalysisSchema.TABLE_ANALYSES, "rowid", null);
@@ -176,7 +177,7 @@ public class SequenceAnalysisCustomizer implements TableCustomizer
             col.setShownInUpdateView(false);
         }
 
-        private static void addFk(Container c, User u, BaseColumnInfo col, String schema, String query, String pkCol, @Nullable String displayCol)
+        private static void addFk(Container c, User u, MutableColumnInfo col, String schema, String query, String pkCol, @Nullable String displayCol)
         {
             if (col.getFk() == null)
             {
@@ -186,9 +187,9 @@ public class SequenceAnalysisCustomizer implements TableCustomizer
             }
         }
 
-        abstract public void customizeColumn(BaseColumnInfo col, AbstractTableInfo ti);
+        abstract public void customizeColumn(MutableColumnInfo col, AbstractTableInfo ti);
 
-        public static void processColumn(BaseColumnInfo col, AbstractTableInfo ti)
+        public static void processColumn(MutableColumnInfo col, AbstractTableInfo ti)
         {
             for (COL_ENUM colEnum : COL_ENUM.values())
             {


### PR DESCRIPTION
#### Rationale
We inconsistently set up certain common "column types" e.g. ParticipantId or Container.  Use the existing ConceptURI property to register ColumnDecorators that configure these columns.

#### Related Pull Requests
https://github.com/LabKey/accounts/pull/142
https://github.com/LabKey/commonAssays/pull/316
https://github.com/LabKey/dataintegration/pull/98
https://github.com/LabKey/MaxQuant/pull/37
https://github.com/LabKey/platform/pull/2121
https://github.com/LabKey/sampleManagement/pull/528