### PR TITLE
Make 'SequenceAnalysis-12.328-12.329.sql' compatible with Postgres 10

### DIFF
--- a/SequenceAnalysis/resources/schemas/dbscripts/postgresql/SequenceAnalysis-12.328-12.329.sql
+++ b/SequenceAnalysis/resources/schemas/dbscripts/postgresql/SequenceAnalysis-12.328-12.329.sql
@@ -7,13 +7,11 @@ CREATE INDEX IDX_asj_status_container_alignment_id_ref_nt_id ON sequenceanalysis
 
 CREATE INDEX IDX_readData_readset ON sequenceanalysis.readData (
 	readset ASC
-)
-INCLUDE(fileid1, fileid2, runid);
+);
 
 CREATE INDEX IDX_quality_metrics_metricname_dataid_readset ON sequenceanalysis.quality_metrics (
 	metricName ASC,
 	dataId ASC,
 	readset ASC
-)
-INCLUDE(metricValue);
+);
 


### PR DESCRIPTION
#### Rationale
`INCLUDE` clause isn't supported by Postgres 10.
LabKey is scheduled to continue [supporting](https://www.labkey.org/Documentation/wiki-page.view?name=supported) Postgres 10 until later this year.

#### Related Pull Requests
* https://github.com/BimberLab/DiscvrLabKeyModules/pull/142

#### Changes
* Remove "include" clause from upgrade script
