### PR TITLE
Update maven repositories in preparation for Artifactory configuration change

### DIFF
--- a/SequenceAnalysis/build.gradle
+++ b/SequenceAnalysis/build.gradle
@@ -9,13 +9,13 @@ import java.util.regex.Matcher
 
 repositories {
    mavenCentral()
+   // Added for org.clojars.chapmanb:sam dependency required by com.github.samtools:htsjdk
    maven {
       url "https://clojars.org/repo"
    }
-   // Added for org.clojars.chapmanb:sam dependency required by com.github.samtools:htsjdk
-   maven {
-      url "https://maven.scijava.org/content/groups/public"
-   }
+   //maven {
+   //   url "https://maven.scijava.org/content/groups/public"
+   //}
 }
 
 dependencies {

--- a/SequenceAnalysis/build.gradle
+++ b/SequenceAnalysis/build.gradle
@@ -16,10 +16,6 @@ repositories {
    maven {
       url "https://maven.scijava.org/content/groups/public"
    }
-   // Added for opencharts dependency (required by biojava)
-   maven {
-      url "https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/"
-   }
 }
 
 dependencies {

--- a/SequenceAnalysis/build.gradle
+++ b/SequenceAnalysis/build.gradle
@@ -12,6 +12,14 @@ repositories {
    maven {
       url "https://clojars.org/repo"
    }
+   // Added for org.clojars.chapmanb:sam dependency required by com.github.samtools:htsjdk
+   maven {
+      url "https://maven.scijava.org/content/groups/public"
+   }
+   // Added for opencharts dependency (required by biojava)
+   maven {
+      url "https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/"
+   }
 }
 
 dependencies {

--- a/SequenceAnalysis/build.gradle
+++ b/SequenceAnalysis/build.gradle
@@ -13,9 +13,6 @@ repositories {
    maven {
       url "https://clojars.org/repo"
    }
-   //maven {
-   //   url "https://maven.scijava.org/content/groups/public"
-   //}
 }
 
 dependencies {

--- a/jbrowse/build.gradle
+++ b/jbrowse/build.gradle
@@ -6,10 +6,6 @@ repositories {
     maven {
         url "https://clojars.org/repo"
     }
-    // Added for opencharts dependency (required by biojava)
-    maven {
-        url "https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/"
-    }
 }
 
 

--- a/jbrowse/build.gradle
+++ b/jbrowse/build.gradle
@@ -1,11 +1,17 @@
 import org.labkey.gradle.util.BuildUtils;
 
 repositories {
-	mavenCentral()
-	maven {
-		url "https://clojars.org/repo"
-	}
+    mavenCentral()
+    // Added for org.clojars.chapmanb:sam dependency required by com.github.samtools:htsjdk
+    maven {
+        url "https://clojars.org/repo"
+    }
+    // Added for opencharts dependency (required by biojava)
+    maven {
+        url "https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/"
+    }
 }
+
 
 dependencies {
     implementation "com.github.samtools:htsjdk:${htsjdkVersion}"


### PR DESCRIPTION
#### Rationale
We plan to update our Artifactory configuration so it no longer proxies for certain remote repositories. This requires that builds that require these remote repositories declare these repositories themselves. We put mavenCentral as the first repository so it won't query our Artifactory instance when looking for external dependencies.

#### Changes
* Add maven repository for scijava to pick up some dependencies not available from mavenCentral
