### PR TITLE
Add scijava repository back to pick up clojars dependency

### DIFF
--- a/SequenceAnalysis/build.gradle
+++ b/SequenceAnalysis/build.gradle
@@ -13,6 +13,10 @@ repositories {
    maven {
       url "https://clojars.org/repo"
    }
+   // Added for org.clojars.chapmanb:sam
+   maven {
+      url "https://maven.scijava.org/content/groups/public"
+   }
 }
 
 dependencies {

--- a/jbrowse/build.gradle
+++ b/jbrowse/build.gradle
@@ -6,6 +6,10 @@ repositories {
     maven {
         url "https://clojars.org/repo"
     }
+    // Added for org.clojars.chapmanb:sam (required by SequenceAnalysis)
+    maven {
+        url "https://maven.scijava.org/content/groups/public"
+    }
 }
 
 


### PR DESCRIPTION
#### Rationale
We want to reduce the usage of Artifactory to a minimum, so we'll stop proxying for the gradle plugins repository and the scijava repository. 

#### Related Pull Requests
* https://github.com/LabKey/server/pull/250

#### Changes
* Add scijava repository
