### PR TITLE
Remove use of jboss repository that is so flaky

### DIFF
--- a/SequenceAnalysis/build.gradle
+++ b/SequenceAnalysis/build.gradle
@@ -14,10 +14,6 @@ repositories {
     maven {
         url "https://clojars.org/repo"
     }
-    // Added for opencharts dependency (required by biojava)
-    maven {
-        url "https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/"
-    }
 }
 
 configurations.all {

--- a/jbrowse/build.gradle
+++ b/jbrowse/build.gradle
@@ -6,10 +6,6 @@ repositories {
     maven {
         url "https://clojars.org/repo"
     }
-	// Added for opencharts dependency (required by biojava)
-	maven {
-		url "https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/"
-	}
 }
 
 dependencies {


### PR DESCRIPTION
#### Rationale
The jboss repository is nothing but trouble because it is quite unstable.  We seem to need only one dependency from that repository (opencharts:opencharts:1.4.2), so this has been deployed to the ext-release-local repository in our Artifactory instance. 

#### Related Pull Requests
* https://github.com/LabKey/BimberLabKeyModules/pull/116

#### Changes
* Remove the jboss repository in various places.