### PR TITLE
Update artifactory URL for 21.11

### DIFF
--- a/jbrowse/.npmrc
+++ b/jbrowse/.npmrc
@@ -1,2 +1,2 @@
 # Set registry for @labkey scopes
-@labkey:registry=https://artifactory.labkey.com/artifactory/api/npm/libs-client/
+@labkey:registry=https://labkey.jfrog.io/artifactory/api/npm/libs-client/

--- a/jbrowse/package-lock.json
+++ b/jbrowse/package-lock.json
@@ -2710,12 +2710,12 @@
     },
     "@labkey/api": {
       "version": "1.6.7",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.7.tgz",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.7.tgz",
       "integrity": "sha1-IL/ynYviKDi8Ik1jZUPdCazpr9I="
     },
     "@labkey/build": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-4.0.1.tgz",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-4.0.1.tgz",
       "integrity": "sha1-kFy1gVVYNBoJNZ6A6FWZnMXtwTM=",
       "dev": true,
       "requires": {
@@ -2767,7 +2767,7 @@
     },
     "@labkey/components": {
       "version": "2.67.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.67.1.tgz",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.67.1.tgz",
       "integrity": "sha1-TYncOBhwKZsLkDXtluadp5K+qns=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.3",


### PR DESCRIPTION
#### Rationale
Artifactory migration

#### Related Pull Requests
* [Server](https://github.com/LabKey/server/pull/281)

#### Changes
* Update artifactory url in package.json and package-lock.json