### PR TITLE
Backport change to picard version

### DIFF
--- a/SequenceAnalysis/build.gradle
+++ b/SequenceAnalysis/build.gradle
@@ -112,7 +112,7 @@ dependencies {
     BuildUtils.addExternalDependency(
             project,
             new ExternalDependency(
-                    "com.github.broadinstitute:picard:2.26.10",
+                    "com.github.broadinstitute:picard:2.27.4",
                     "Picard Tools Lib",
                     "PicardTools",
                     "https://github.com/broadinstitute/picard",


### PR DESCRIPTION
@labkey-danield I believe backporting this change will fix it. I think the sequence_tools artifact used is the same across all releases, so updated picard there probably requires a change in the branches using it.

I think this alone will do it, but we'll see what the TC build does.