### PR TITLE
Add evaluation dependency to account for different ordering with new gradle plugins version

### DIFF
--- a/SequenceAnalysis/build.gradle
+++ b/SequenceAnalysis/build.gradle
@@ -157,8 +157,10 @@ dependencies {
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "published", depExtension: "module")
 }
 
+
 if (project.findProject(BuildUtils.getTestProjectPath(project.gradle)) != null && project.hasProperty("teamcity"))
 {
+    project.evaluationDependsOn(BuildUtils.getTestProjectPath(project.gradle))
     def testProject = project.findProject(BuildUtils.getTestProjectPath(project.gradle))
     def createPipelineConfigTask = project.tasks.register("createPipelineConfig", Copy) {
         Copy task ->


### PR DESCRIPTION
#### Rationale
Because of a dependency on the test project tasks, adding an evaluation dependency is needed. Updates to the gradlePlugin make the evaluation order not do the right thing by default.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/157

#### Changes
* Add evaluation order dependency
