### PR TITLE
Add missing task inputs/outputs for jbrowse npm tasks

### DIFF
--- a/jbrowse/build.gradle
+++ b/jbrowse/build.gradle
@@ -25,17 +25,19 @@ dependencies {
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "pipeline"), depProjectConfig: "published", depExtension: "module")
 }
 
-project.tasks.named("npm_run_build-prod").configure {
-    inputs.dir(project.file("./node_modules/@jbrowse/cli"))
+def jbPkgTask = project.tasks.named("npm_run_jb-pkg")
+
+jbPkgTask.configure {
+    outputs.cacheIf {false}
+
+    inputs.dir(project.file("./node_modules/@jbrowse/cli")).withPathSensitivity(PathSensitivity.RELATIVE)
     outputs.dir(project.file("./resources/external/jb-cli"))
+}
+
+project.tasks.named("npm_run_build-prod").configure {
+    finalizedBy jbPkgTask.get()
 }
 
 project.tasks.named("npm_run_build-dev").configure {
-    inputs.dir(project.file("./node_modules/@jbrowse/cli"))
-    outputs.dir(project.file("./resources/external/jb-cli"))
-}
-
-project.tasks.named("npm_run_jb-pkg").configure {
-    inputs.dir(project.file("./node_modules/@jbrowse/cli"))
-    outputs.dir(project.file("./resources/external/jb-cli"))
+    finalizedBy jbPkgTask.get()
 }

--- a/jbrowse/build.gradle
+++ b/jbrowse/build.gradle
@@ -24,3 +24,18 @@ dependencies {
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:DiscvrLabKeyModules:SequenceAnalysis", depProjectConfig: "published", depExtension: "module")
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "pipeline"), depProjectConfig: "published", depExtension: "module")
 }
+
+project.tasks.named("npm_run_build-prod").configure {
+    inputs.dir(project.file("./node_modules/@jbrowse/cli")).withPathSensitivity(PathSensitivity.RELATIVE)
+    outputs.dir(project.file("./resources/external/jb-cli")).withPathSensitivity(PathSensitivity.RELATIVE)
+}
+
+project.tasks.named("npm_run_build-dev").configure {
+    inputs.dir(project.file("./node_modules/@jbrowse/cli")).withPathSensitivity(PathSensitivity.RELATIVE)
+    outputs.dir(project.file("./resources/external/jb-cli")).withPathSensitivity(PathSensitivity.RELATIVE)
+}
+
+project.tasks.named("npm_run_jb-pkg").configure {
+    inputs.dir(project.file("./node_modules/@jbrowse/cli")).withPathSensitivity(PathSensitivity.RELATIVE)
+    outputs.dir(project.file("./resources/external/jb-cli")).withPathSensitivity(PathSensitivity.RELATIVE)
+}

--- a/jbrowse/build.gradle
+++ b/jbrowse/build.gradle
@@ -26,16 +26,16 @@ dependencies {
 }
 
 project.tasks.named("npm_run_build-prod").configure {
-    inputs.dir(project.file("./node_modules/@jbrowse/cli")).withPathSensitivity(PathSensitivity.RELATIVE)
-    outputs.dir(project.file("./resources/external/jb-cli")).withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.dir(project.file("./node_modules/@jbrowse/cli"))
+    outputs.dir(project.file("./resources/external/jb-cli"))
 }
 
 project.tasks.named("npm_run_build-dev").configure {
-    inputs.dir(project.file("./node_modules/@jbrowse/cli")).withPathSensitivity(PathSensitivity.RELATIVE)
-    outputs.dir(project.file("./resources/external/jb-cli")).withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.dir(project.file("./node_modules/@jbrowse/cli"))
+    outputs.dir(project.file("./resources/external/jb-cli"))
 }
 
 project.tasks.named("npm_run_jb-pkg").configure {
-    inputs.dir(project.file("./node_modules/@jbrowse/cli")).withPathSensitivity(PathSensitivity.RELATIVE)
-    outputs.dir(project.file("./resources/external/jb-cli")).withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.dir(project.file("./node_modules/@jbrowse/cli"))
+    outputs.dir(project.file("./resources/external/jb-cli"))
 }

--- a/jbrowse/package.json
+++ b/jbrowse/package.json
@@ -7,8 +7,8 @@
     "build": "npm run build-dev",
     "start": "cross-env NODE_ENV=development LK_MODULE_CONTAINER=DiscvrLabKeyModules LK_MODULE=jbrowse webpack-dev-server --config config/watch.config.js",
     "build-no-pkg": "npm run clean && cross-env NODE_ENV=development LK_MODULE_CONTAINER=DiscvrLabKeyModules LK_MODULE=jbrowse webpack --config config/dev.config.js --progress --profile",
-    "build-dev": "npm run build-no-pkg && npm run jb-pkg",
-    "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map LK_MODULE_CONTAINER=DiscvrLabKeyModules LK_MODULE=jbrowse webpack --config config/prod.config.js --progress --profile && npm run jb-pkg",
+    "build-dev": "npm run build-no-pkg",
+    "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map LK_MODULE_CONTAINER=DiscvrLabKeyModules LK_MODULE=jbrowse webpack --config config/prod.config.js --progress --profile",
     "clean": "rimraf resources/web/gen && rimraf resources/web/jbrowse/gen && rimraf resources/views/gen && rimraf resources/views/browser*",
     "test": "cross-env NODE_ENV=test jest",
     "jb-pkg": "pkg ./node_modules/@jbrowse/cli --out-path ./resources/external/jb-cli"


### PR DESCRIPTION
#### Rationale
Building the jbrowse module and collecting the jbrowse cli tools are independent tasks. Separating them in package.json and teaching gradle about them will allow Gradle to build and cache them more intelligently.

#### Related Pull Requests
* https://github.com/BimberLab/DiscvrLabKeyModules/pull/174

#### Changes
* Add missing task inputs/outputs for jbrowse npm tasks
* Don't copy jbrowse cli tool as part of `npm run build-*` scripts
