### PR TITLE
Add expicit depends on for module resources

### DIFF
--- a/jbrowse/build.gradle
+++ b/jbrowse/build.gradle
@@ -34,6 +34,8 @@ jbPkgTask.configure {
     outputs.dir(project.file("./resources/external/jb-cli"))
 }
 
+project.tasks.processModuleResources.dependsOn(jbPkgTask)
+
 project.tasks.named("npm_run_build-prod").configure {
     finalizedBy jbPkgTask.get()
 }


### PR DESCRIPTION
#### Rationale
Gradle 8 requires better dependency declarations.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/408

#### Changes
* Add explicit task declaration
