### PR TITLE
Issue 47550: Upgrade HTSJDK to 3.0.1

### DIFF
--- a/SequenceAnalysis/build.gradle
+++ b/SequenceAnalysis/build.gradle
@@ -116,7 +116,7 @@ dependencies {
     BuildUtils.addExternalDependency(
             project,
             new ExternalDependency(
-                    "com.github.broadinstitute:picard:2.27.4",
+                    "com.github.broadinstitute:picard:3.0.0",
                     "Picard Tools Lib",
                     "PicardTools",
                     "https://github.com/broadinstitute/picard",


### PR DESCRIPTION
#### Rationale
There are new versions - let's use them.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/425

#### Changes
* Update and keep in sync with HTSJDK version
