### PR TITLE
Avoid unnecessary Gradle task configuration

### DIFF
--- a/SequenceAnalysis/build.gradle
+++ b/SequenceAnalysis/build.gradle
@@ -1,10 +1,8 @@
-import org.labkey.gradle.plugin.TeamCity
 import org.labkey.gradle.plugin.extension.ServerDeployExtension
 import org.labkey.gradle.plugin.extension.TeamCityExtension
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
 import org.labkey.gradle.util.PropertiesUtils
-import org.labkey.gradle.util.ExternalDependency
 
 import java.util.regex.Matcher
 
@@ -188,11 +186,11 @@ if (project.findProject(BuildUtils.getTestProjectPath(project.gradle)) != null &
     }
 }
 
-project.task("copyJars",
-        type: Copy,
-        group: "Build",
-        description: "Copy commons-math3 JAR to module's lib directory",
+project.tasks.register("copyJars", Copy)
         { CopySpec copy ->
+            copy.group = "Build"
+            copy.description = "Copy commons-math3 JAR to module's lib directory"
+
             copy.setDuplicatesStrategy(DuplicatesStrategy.EXCLUDE)
             copy.from(project.configurations.external)
             copy.into new File("${project.labkey.explodedModuleLibDir}")
@@ -200,7 +198,6 @@ project.task("copyJars",
                 "**commons-math3-**.jar"
             }
         }
-)
 
-project.tasks.module.dependsOn(project.tasks.copyJars)
-project.tasks.copyJars.mustRunAfter(project.tasks.populateExplodedLib)
+project.tasks.named('module').configure { dependsOn(project.tasks.copyJars) }
+project.tasks.named('copyJars').configure { mustRunAfter(project.tasks.populateExplodedLib) }

--- a/SequenceAnalysis/build.gradle
+++ b/SequenceAnalysis/build.gradle
@@ -1,8 +1,10 @@
+import org.labkey.gradle.plugin.TeamCity
 import org.labkey.gradle.plugin.extension.ServerDeployExtension
 import org.labkey.gradle.plugin.extension.TeamCityExtension
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
 import org.labkey.gradle.util.PropertiesUtils
+import org.labkey.gradle.util.ExternalDependency
 
 import java.util.regex.Matcher
 

--- a/jbrowse/build.gradle
+++ b/jbrowse/build.gradle
@@ -34,7 +34,9 @@ jbPkgTask.configure {
     outputs.dir(project.file("./resources/external/jb-cli"))
 }
 
-project.tasks.processModuleResources.dependsOn(jbPkgTask)
+project.tasks.named('processModuleResources').configure {
+    dependsOn jbPkgTask
+}
 
 project.tasks.named("npm_run_build-prod").configure {
     finalizedBy jbPkgTask.get()


### PR DESCRIPTION
#### Rationale
Using [task configuration avoidance APIs](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html) can make builds more efficient.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/171

#### Changes
* Update gradle task references to avoid unnecessary configuration