### PR TITLE
Update other references use ObjectToXml custom subclass

### DIFF
--- a/SequenceAnalysis/tools/pipeline_config/remoteMuleConfig.xml
+++ b/SequenceAnalysis/tools/pipeline_config/remoteMuleConfig.xml
@@ -61,8 +61,8 @@
             returnClass="javax.jms.TextMessage"/>
         <transformer name="JMSMessageToJob" className="org.labkey.pipeline.mule.transformers.JMSMessageToPipelineJob"
             returnClass="org.labkey.api.pipeline.PipelineJob"/>
-        <transformer name="StatusToXML" className="org.mule.transformers.xml.ObjectToXml"
-            returnClass="java.lang.String"/>
+        <transformer name="StatusToXML" className="org.labkey.pipeline.mule.transformers.ObjectToXml"
+                     returnClass="java.lang.String"/>
         <transformer name="XMLToJMSMessage" className="org.mule.providers.jms.transformers.ObjectToJMSMessage"
             returnClass="javax.jms.TextMessage" />
         <transformer name="NoOpTransformer" className="org.labkey.pipeline.mule.transformers.NoOpTransformer"


### PR DESCRIPTION
#### Rationale
With the XStream update in 23.7, we need to consistently use a custom serializer subclass

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4672

#### Changes
* Apply edit already made earlier to webserverMuleConfig.xml
