### PR TITLE
Issue 48499: Use preferred SecurityPolicyManager.savePolicy() variant

### DIFF
--- a/OpenLdapSync/src/org/labkey/openldapsync/ldap/LdapSyncRunner.java
+++ b/OpenLdapSync/src/org/labkey/openldapsync/ldap/LdapSyncRunner.java
@@ -893,7 +893,7 @@ public class LdapSyncRunner implements Job
             Container project = ContainerManager.getForPath(PROJECT_NAME);
             if (project == null)
             {
-                project = ContainerManager.createContainer(ContainerManager.getRoot(), PROJECT_NAME);
+                project = ContainerManager.createContainer(ContainerManager.getRoot(), PROJECT_NAME, TestContext.get().getUser());
                 Set<Module> modules = new HashSet<>();
                 modules.addAll(project.getActiveModules());
                 modules.add(ModuleLoader.getInstance().getModule(OpenLdapSyncModule.NAME));

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceIntegrationTests.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceIntegrationTests.java
@@ -244,7 +244,7 @@ public class SequenceIntegrationTests
             Container project = ContainerManager.getForPath(projectName);
             if (project == null)
             {
-                project = ContainerManager.createContainer(ContainerManager.getRoot(), projectName);
+                project = ContainerManager.createContainer(ContainerManager.getRoot(), projectName, TestContext.get().getUser());
 
                 //disable search so we dont get conflicts when deleting folder quickly
                 ContainerManager.updateSearchable(project, false, TestContext.get().getUser());

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/BamIterator.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/BamIterator.java
@@ -263,7 +263,7 @@ public class BamIterator
             Container project = ContainerManager.getForPath(PROJECT_NAME);
             if (project == null)
             {
-                project = ContainerManager.createContainer(ContainerManager.getRoot(), PROJECT_NAME);
+                project = ContainerManager.createContainer(ContainerManager.getRoot(), PROJECT_NAME, TestContext.get().getUser());
                 Set<Module> modules = new HashSet<>();
                 modules.addAll(project.getActiveModules());
                 modules.add(ModuleLoader.getInstance().getModule(SequenceAnalysisModule.NAME));

--- a/cluster/src/org/labkey/cluster/pipeline/TestCase.java
+++ b/cluster/src/org/labkey/cluster/pipeline/TestCase.java
@@ -52,7 +52,7 @@ public class TestCase extends Assert
         Container project = ContainerManager.getForPath(PROJECT_NAME);
         if (project == null)
         {
-            project = ContainerManager.createContainer(ContainerManager.getRoot(), PROJECT_NAME);
+            project = ContainerManager.createContainer(ContainerManager.getRoot(), PROJECT_NAME, TestContext.get().getUser());
             Set<Module> modules = new HashSet<>();
             modules.addAll(project.getActiveModules());
             modules.add(ModuleLoader.getInstance().getModule(ClusterModule.class));
@@ -102,19 +102,19 @@ public class TestCase extends Assert
     public void basicTest() throws Exception
     {
         Container c = ContainerManager.getForPath(PROJECT_NAME);
-        for (RemoteExecutionEngine engine : PipelineJobService.get().getRemoteExecutionEngines())
+        for (RemoteExecutionEngine<?> engine : PipelineJobService.get().getRemoteExecutionEngines())
         {
             _log.info("testing engine: " + engine.getType());
-            if (engine instanceof AbstractClusterExecutionEngine)
+            if (engine instanceof AbstractClusterExecutionEngine<?> acee)
             {
-                runTestJob(c, TestContext.get().getUser(), (AbstractClusterExecutionEngine) engine);
+                runTestJob(c, TestContext.get().getUser(), acee);
             }
         }
     }
 
     public static class TestRunner implements ClusterService.ClusterRemoteTask
     {
-        public long _sleep = 0;
+        public long _sleep = 0l;
 
         public TestRunner(long sleep)
         {


### PR DESCRIPTION
#### Rationale
We're uneven in terms of the validation and auditing we do for saving SecurityPolicies and related updates, and want to be more consistent.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4704

#### Changes
* Let modules register ContainerSecurableResourceProviders instead of having Container know about them all
* Remove the `savePolicy` and `createContainer` methods that don't take a user, check permissions, or log for audit purposes
* Introduce `User.getAdminServiceUser()` for `sudo` like scenarios or when we're doing an operation not initiated by a user, like bootstrapping the server
* Update callers