### PR TITLE
Migrate User.isInSiteAdminGroup() -> User.hasSiteAdminPermission()

### DIFF
--- a/cluster/src/org/labkey/cluster/query/RecoverCompletedJobsButton.java
+++ b/cluster/src/org/labkey/cluster/query/RecoverCompletedJobsButton.java
@@ -25,6 +25,6 @@ public class RecoverCompletedJobsButton extends SimpleButtonConfigFactory
     @Override
     public boolean isAvailable(TableInfo ti)
     {
-        return ti.getUserSchema().getUser().isInSiteAdminGroup() && (super.isAvailable(ti) || ContainerManager.getRoot().equals(ti.getUserSchema().getContainer()));
+        return ti.getUserSchema().getUser().hasSiteAdminPermission() && (super.isAvailable(ti) || ContainerManager.getRoot().equals(ti.getUserSchema().getContainer()));
     }
 }

--- a/cluster/src/org/labkey/cluster/query/ReplaceJobStoreButton.java
+++ b/cluster/src/org/labkey/cluster/query/ReplaceJobStoreButton.java
@@ -25,6 +25,6 @@ public class ReplaceJobStoreButton extends SimpleButtonConfigFactory
     @Override
     public boolean isAvailable(TableInfo ti)
     {
-        return ti.getUserSchema().getUser().isInSiteAdminGroup() && (super.isAvailable(ti) || ContainerManager.getRoot().equals(ti.getUserSchema().getContainer()));
+        return ti.getUserSchema().getUser().hasSiteAdminPermission() && (super.isAvailable(ti) || ContainerManager.getRoot().equals(ti.getUserSchema().getContainer()));
     }
 }


### PR DESCRIPTION
#### Rationale
Calling `User.isInSiteAdminGroup()` will return incorrect results for users and groups assigned directly to the role as well as impersonation scenarios.