### PR TITLE
Restrict scijava repository to specific dependencies

### DIFF
--- a/SequenceAnalysis/build.gradle
+++ b/SequenceAnalysis/build.gradle
@@ -1,19 +1,19 @@
-import org.labkey.gradle.plugin.TeamCity
 import org.labkey.gradle.plugin.extension.ServerDeployExtension
 import org.labkey.gradle.plugin.extension.TeamCityExtension
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
 import org.labkey.gradle.util.PropertiesUtils
-import org.labkey.gradle.util.ExternalDependency
 
 import java.util.regex.Matcher
 
 repositories {
-   mavenCentral()
-   // Added for jhdf5 from FASTQC / sequence analysis module
-   maven {
-      url "https://maven.scijava.org/content/groups/public/"
-   }
+    mavenCentral()
+    maven {
+        url "https://maven.scijava.org/content/groups/public/"
+        content {
+            includeGroup "cisd" //jhdf5
+        }
+    }
 }
 
 configurations.all {

--- a/SequenceAnalysis/build.gradle
+++ b/SequenceAnalysis/build.gradle
@@ -1,8 +1,10 @@
+import org.labkey.gradle.plugin.TeamCity
 import org.labkey.gradle.plugin.extension.ServerDeployExtension
 import org.labkey.gradle.plugin.extension.TeamCityExtension
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
 import org.labkey.gradle.util.PropertiesUtils
+import org.labkey.gradle.util.ExternalDependency
 
 import java.util.regex.Matcher
 

--- a/jbrowse/build.gradle
+++ b/jbrowse/build.gradle
@@ -2,9 +2,11 @@ import org.labkey.gradle.util.BuildUtils;
 
 repositories {
 	mavenCentral()
-	// Added for jhdf5 from FASTQC / sequence analysis module
 	maven {
 		url "https://maven.scijava.org/content/repositories/public/"
+		content {
+			includeGroup "cisd"
+		}
 	}
 }
 

--- a/jbrowse/build.gradle
+++ b/jbrowse/build.gradle
@@ -5,7 +5,8 @@ repositories {
 	maven {
 		url "https://maven.scijava.org/content/repositories/public/"
 		content {
-			includeGroup "cisd"
+			// Transitive dependency from SequenceAnalysis
+			includeGroup "cisd" //jhdf5
 		}
 	}
 }


### PR DESCRIPTION
#### Rationale
Gradle should only query scijava for dependencies that we expect it to contain
```
> Could not resolve all files for configuration ':server:modules:DiscvrLabKeyModules:jbrowse:detachedConfiguration1'.
   > Could not resolve org.nodejs:node:18.18.1.
     Required by:
         project :server:modules:DiscvrLabKeyModules:jbrowse
      > Could not resolve org.nodejs:node:18.18.1.
         > Could not get resource 'https://maven.scijava.org/content/repositories/public/org/nodejs/node/18.18.1/node-18.18.1.pom'.
            > Could not GET 'https://maven.scijava.org/content/repositories/public/org/nodejs/node/18.18.1/node-18.18.1.pom'.
               > Connect to maven.scijava.org:443 [maven.scijava.org/144.92.48.199] failed: Connect timed out
```

#### Related Pull Requests
* N/A

#### Changes
* Define `includeGroup` for scijava maven repository
