### PR TITLE
Fix more tests that launch ClusterStartup

### DIFF
--- a/SequenceAnalysis/build.gradle
+++ b/SequenceAnalysis/build.gradle
@@ -193,7 +193,9 @@ if (project.findProject(BuildUtils.getTestProjectPath(project.gradle)) != null &
                 return newLine
 
             })
-            task.destinationDir = new File("${ServerDeployExtension.getServerDeployDirectory(project)}/config")
+            task.destinationDir = BuildUtils.useEmbeddedTomcat(project)
+                    ? new File("${BuildUtils.getEmbeddedConfigPath(project)}")
+                    : new File("${ServerDeployExtension.getServerDeployDirectory(project)}/config")
     }
     testProject.tasks.named("startTomcat").configure {
         dependsOn(createPipelineConfigTask)

--- a/SequenceAnalysis/build.gradle
+++ b/SequenceAnalysis/build.gradle
@@ -193,9 +193,7 @@ if (project.findProject(BuildUtils.getTestProjectPath(project.gradle)) != null &
                 return newLine
 
             })
-            task.destinationDir = BuildUtils.useEmbeddedTomcat(project)
-                    ? new File("${BuildUtils.getEmbeddedConfigPath(project)}")
-                    : new File("${ServerDeployExtension.getServerDeployDirectory(project)}/config")
+            task.destinationDir = new File("${ServerDeployExtension.getServerDeployDirectory(project)}/config")
     }
     testProject.tasks.named("startTomcat").configure {
         dependsOn(createPipelineConfigTask)

--- a/SequenceAnalysis/build.gradle
+++ b/SequenceAnalysis/build.gradle
@@ -1,6 +1,7 @@
 import org.labkey.gradle.plugin.TeamCity
 import org.labkey.gradle.plugin.extension.ServerDeployExtension
 import org.labkey.gradle.plugin.extension.TeamCityExtension
+import org.labkey.gradle.task.DoThenSetup
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
 import org.labkey.gradle.util.PropertiesUtils
@@ -174,6 +175,7 @@ dependencies {
 if (project.findProject(BuildUtils.getTestProjectPath(project.gradle)) != null && project.hasProperty("teamcity"))
 {
     project.evaluationDependsOn(BuildUtils.getTestProjectPath(project.gradle))
+    def configDir = "${ServerDeployExtension.getServerDeployDirectory(project)}/config"
     def testProject = project.findProject(BuildUtils.getTestProjectPath(project.gradle))
     def createPipelineConfigTask = project.tasks.register("createPipelineConfig", Copy) {
         Copy task ->
@@ -193,12 +195,25 @@ if (project.findProject(BuildUtils.getTestProjectPath(project.gradle)) != null &
                 return newLine
 
             })
-            task.destinationDir = BuildUtils.useEmbeddedTomcat(project)
-                    ? new File("${BuildUtils.getEmbeddedConfigPath(project)}")
-                    : new File("${ServerDeployExtension.getServerDeployDirectory(project)}/config")
+            task.destinationDir = new File(configDir)
+
+            if (BuildUtils.useEmbeddedTomcat(project)) {
+                task.doFirst {
+                    new File(new File(BuildUtils.getEmbeddedConfigPath(project)), "application.properties") << "\n${configDir}"
+                }
+
+                rootProject.allprojects {
+                    task.mustRunAfter tasks.withType(DoThenSetup)
+                }
+            }
     }
     testProject.tasks.named("startTomcat").configure {
         dependsOn(createPipelineConfigTask)
+        if (BuildUtils.useEmbeddedTomcat(project)) {
+            it.doFirst {
+                new File(new File(BuildUtils.getEmbeddedConfigPath(project)), "application.properties") << "\ncontext.pipelineConfig=${configDir}"
+            }
+        }
     }
 }
 


### PR DESCRIPTION
#### Rationale
Tests outside the Pipeline module also exercise ClusterStartup.

https://teamcity.labkey.org/buildConfiguration/LabKey_EmbeddedTomcat_Community_ExternalModulesTestPostgres/2901427?hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildChangesSection=true&expandBuildTestsSection=true&expandBuildDeploymentsSection=false

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5224

#### Changes
* Use the new API that helps provide the right command line after extracting JARs
