### PR TITLE
Suppress UOE for containers configured to use S3

### DIFF
--- a/blast/src/org/labkey/blast/BLASTManager.java
+++ b/blast/src/org/labkey/blast/BLASTManager.java
@@ -44,6 +44,9 @@ import org.labkey.blast.pipeline.BlastPipelineJob;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Date;
 import java.util.Map;
 
@@ -106,13 +109,13 @@ public class BLASTManager
     public File getDatabaseDir(Container c, boolean createIfDoesntExist)
     {
         FileContentService fileService = FileContentService.get();
-        File fileRoot = fileService == null ? null : fileService.getFileRoot(c, FileContentService.ContentType.files);
-        if (fileRoot == null || !fileRoot.exists())
+        Path fileRoot = fileService == null ? null : fileService.getFileRootPath(c, FileContentService.ContentType.files);
+        if (fileRoot == null || fileRoot.getFileSystem() != FileSystems.getDefault())
         {
             return null;
         }
 
-        File ret = new File(fileRoot, ".blastDB");
+        File ret = new File(fileRoot.toFile(), ".blastDB");
         if (createIfDoesntExist && !ret.exists())
         {
             ret.mkdirs();


### PR DESCRIPTION
#### Rationale
Clean up logging on dev machines. For folders configured to use a S3 file root:

```
RROR PipelineJob              2024-03-04T02:00:24,937            JobThread-2.2 : (from pipeline job log file /Users/jeckels/labkey/build/deploy/files/@files/system_maintenance_2024-03-04_01-59-59.log: Failure running DeleteBlastArtifacts)
java.lang.UnsupportedOperationException: null
	at com.upplication.s3fs.S3Path.toFile(S3Path.java:509) ~[s3fs-2.2.2.16.jar:?]
	at org.labkey.filecontent.FileContentServiceImpl.getFileRoot(FileContentServiceImpl.java:218) ~[filecontent-24.4-SNAPSHOT.jar:?]
	at org.labkey.blast.BLASTManager.getDatabaseDir(BLASTManager.java:109) ~[blast-24.4-SNAPSHOT.jar:?]
	at org.labkey.blast.BLASTMaintenanceTask.processContainerDB(BLASTMaintenanceTask.java:181) ~[blast-24.4-SNAPSHOT.jar:?]
	at org.labkey.blast.BLASTMaintenanceTask.processContainerDB(BLASTMaintenanceTask.java:229) ~[blast-24.4-SNAPSHOT.jar:?]
	at org.labkey.blast.BLASTMaintenanceTask.run(BLASTMaintenanceTask.java:175) ~[blast-24.4-SNAPSHOT.jar:?]
	at org.labkey.api.util.MaintenancePipelineJob.run(MaintenancePipelineJob.java:84) [api-24.4-SNAPSHOT.jar:?]
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) [?:?]
	at java.base/java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:264) [?:?]
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java) [?:?]
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) [?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
	at java.base/java.lang.Thread.run(Thread.java:833) [?:?]
```

#### Changes
* Bail out for non-local file storage