### PR TITLE
Exclude threetenbp dependency (#284) (#285)

### DIFF
--- a/SequenceAnalysis/build.gradle
+++ b/SequenceAnalysis/build.gradle
@@ -137,6 +137,8 @@ dependencies {
             {
                 exclude group: "javax.servlet", module: "servlet-api"
                 exclude group: "org.apache.commons", module: "commons-collections4"
+                // NOTE: this is a dependency of picard->google-cloud-storage. there is a vunerability in 1.6.8 that does not seem fixed as of 1.6.9
+                exclude group: "org.threeten", module: "threetenbp"
             }
     )
 


### PR DESCRIPTION
#### Rationale
Back-port exclusion to suppress OWASP complaints in earlier releases