### PR TITLE
Escape `context.pipelineConfig` property for tests

### DIFF
--- a/SequenceAnalysis/build.gradle
+++ b/SequenceAnalysis/build.gradle
@@ -177,7 +177,7 @@ dependencies {
 if (project.findProject(BuildUtils.getTestProjectPath(project.gradle)) != null && project.hasProperty("teamcity"))
 {
     project.evaluationDependsOn(BuildUtils.getTestProjectPath(project.gradle))
-    def configDir = "${ServerDeployExtension.getServerDeployDirectory(project)}/config"
+    def configDir = new File(ServerDeployExtension.getServerDeployDirectory(project), "config")
     def testProject = project.findProject(BuildUtils.getTestProjectPath(project.gradle))
     def createPipelineConfigTask = project.tasks.register("createPipelineConfig", Copy) {
         Copy task ->
@@ -197,13 +197,9 @@ if (project.findProject(BuildUtils.getTestProjectPath(project.gradle)) != null &
                 return newLine
 
             })
-            task.destinationDir = new File(configDir)
+            task.destinationDir = configDir
 
             if (BuildUtils.useEmbeddedTomcat(project)) {
-                task.doFirst {
-                    new File(new File(BuildUtils.getEmbeddedConfigPath(project)), "application.properties") << "\n${configDir}"
-                }
-
                 rootProject.allprojects {
                     task.mustRunAfter tasks.withType(DoThenSetup)
                 }
@@ -213,7 +209,8 @@ if (project.findProject(BuildUtils.getTestProjectPath(project.gradle)) != null &
         dependsOn(createPipelineConfigTask)
         if (BuildUtils.useEmbeddedTomcat(project)) {
             it.doFirst {
-                new File(new File(BuildUtils.getEmbeddedConfigPath(project)), "application.properties") << "\ncontext.pipelineConfig=${configDir}"
+                new File(new File(BuildUtils.getEmbeddedConfigPath(project)), "application.properties")
+                        << "\ncontext.pipelineConfig=${configDir.getAbsolutePath().replace("\\", "\\\\")}"
             }
         }
     }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceRemoteIntegrationTests.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceRemoteIntegrationTests.java
@@ -215,6 +215,8 @@ public class SequenceRemoteIntegrationTests extends SequenceIntegrationTests.Abs
         ProcessBuilder pb = new ProcessBuilder(args);
         pb.directory(workDir);
 
+        _log.info("Executing job: " + pb.directory().getAbsolutePath() + " $ " + String.join(" ", pb.command()));
+
         Process proc;
         try
         {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceRemoteIntegrationTests.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceRemoteIntegrationTests.java
@@ -81,7 +81,6 @@ public class SequenceRemoteIntegrationTests extends SequenceIntegrationTests.Abs
                         path = PipelineJobService.get().getAppProperties().getToolsDirectory();
                     }
 
-                    path = path.replaceAll("\\\\", "/").replace("deploy/bin", "deploy/embedded/bin");
                     line = line.replaceAll("@@SEQUENCEANALYSIS_TOOLS@@", path);
                     _log.info("Writing to pipelineConfig.xml: " + line);
                 }
@@ -215,7 +214,7 @@ public class SequenceRemoteIntegrationTests extends SequenceIntegrationTests.Abs
         ProcessBuilder pb = new ProcessBuilder(args);
         pb.directory(workDir);
 
-        _log.info("Executing job: " + pb.directory().getAbsolutePath() + " $ " + String.join(" ", pb.command()));
+        _log.info("Executing job in '" + pb.directory().getAbsolutePath() + "': " + String.join(" ", pb.command()));
 
         Process proc;
         try

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceRemoteIntegrationTests.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceRemoteIntegrationTests.java
@@ -83,10 +83,12 @@ public class SequenceRemoteIntegrationTests extends SequenceIntegrationTests.Abs
 
                     path = path.replaceAll("\\\\", "/");
                     line = line.replaceAll("@@SEQUENCEANALYSIS_TOOLS@@", path);
+                    _log.info("Writing to pipelineConfig.xml: " + line);
                 }
                 else if (line.contains("@@WORK_DIR@@"))
                 {
                     line = line.replaceAll("@@WORK_DIR@@", outDir.getPath().replaceAll("\\\\", "/"));
+                    _log.info("Writing to pipelineConfig.xml: " + line);
                 }
 
                 writer.println(line);

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceRemoteIntegrationTests.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceRemoteIntegrationTests.java
@@ -81,6 +81,7 @@ public class SequenceRemoteIntegrationTests extends SequenceIntegrationTests.Abs
                         path = PipelineJobService.get().getAppProperties().getToolsDirectory();
                     }
 
+                    path = path.replaceAll("\\\\", "/");
                     line = line.replaceAll("@@SEQUENCEANALYSIS_TOOLS@@", path);
                     _log.info("Writing to pipelineConfig.xml: " + line);
                 }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceRemoteIntegrationTests.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceRemoteIntegrationTests.java
@@ -81,7 +81,7 @@ public class SequenceRemoteIntegrationTests extends SequenceIntegrationTests.Abs
                         path = PipelineJobService.get().getAppProperties().getToolsDirectory();
                     }
 
-                    path = path.replaceAll("\\\\", "/");
+                    path = path.replaceAll("\\\\", "/").replace("deploy/bin", "deploy/embedded/bin");
                     line = line.replaceAll("@@SEQUENCEANALYSIS_TOOLS@@", path);
                     _log.info("Writing to pipelineConfig.xml: " + line);
                 }


### PR DESCRIPTION
#### Rationale
Need properly escape file paths for `application.properties`.

#### Related Pull Requests
* #270 

#### Changes
* Escape `context.pipelineConfig` property for tests
* Add some logging to `SequenceRemoteIntegrationTests.java`
