### PR TITLE
Remove empty <permissions> element

### DIFF
--- a/cluster/resources/views/begin.view.xml
+++ b/cluster/resources/views/begin.view.xml
@@ -1,7 +1,4 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Cluster Module">
-    <permissions>
-
-    </permissions>
     <dependencies>
         <dependency path="Ext4ClientApi" />
     </dependencies>


### PR DESCRIPTION
#### Rationale
The `<permissions>` element is deprecated and unnecessary here. Before and after, the required permissions are "read" in this case.