### PR TITLE
Remove useEmbeddedTomcat property and other support for standalone bu…

### DIFF
--- a/SequenceAnalysis/build.gradle
+++ b/SequenceAnalysis/build.gradle
@@ -185,19 +185,15 @@ if (project.findProject(BuildUtils.getTestProjectPath(project.gradle)) != null &
             })
             task.destinationDir = configDir
 
-            if (BuildUtils.useEmbeddedTomcat(project)) {
-                rootProject.allprojects {
-                    task.mustRunAfter tasks.withType(DoThenSetup)
-                }
+            rootProject.allprojects {
+                task.mustRunAfter tasks.withType(DoThenSetup)
             }
     }
     testProject.tasks.named("startTomcat").configure {
         dependsOn(createPipelineConfigTask)
-        if (BuildUtils.useEmbeddedTomcat(project)) {
-            it.doFirst {
-                new File(new File(BuildUtils.getEmbeddedConfigPath(project)), "application.properties")
-                        << "\ncontext.pipelineConfig=${configDir.getAbsolutePath().replace("\\", "\\\\")}"
-            }
+        it.doFirst {
+            new File(new File(BuildUtils.getEmbeddedConfigPath(project)), "application.properties")
+                    << "\ncontext.pipelineConfig=${configDir.getAbsolutePath().replace("\\", "\\\\")}"
         }
     }
 }


### PR DESCRIPTION
#### Rationale
Support for the `useEmbeddedTomcat` property is being removed in the next Gradle Plugin version

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/216