### PR TITLE
Mark modules that support both databases

### DIFF
--- a/OpenLdapSync/module.properties
+++ b/OpenLdapSync/module.properties
@@ -5,3 +5,4 @@ License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 ManageVersion: false
 URL: https://github.com/BimberLab/DiscvrLabKeyModules
+SupportedDatabases: mssql, pgsql

--- a/QueryExtensions/module.properties
+++ b/QueryExtensions/module.properties
@@ -4,3 +4,4 @@ Label: Query Extensions
 Description: This module contains low-level extensions to the LabKey Query layer
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/SequenceAnalysis/module.properties
+++ b/SequenceAnalysis/module.properties
@@ -5,3 +5,4 @@ Description: This is the core module for DISCVR-seq, which is a suite of modules
 URL: https://github.com/BimberLab/DiscvrLabKeyModules
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/Studies/module.properties
+++ b/Studies/module.properties
@@ -4,3 +4,4 @@ Description: Extensions to the study framework, designed to more flexibly manage
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 ManageVersion: false
+SupportedDatabases: mssql, pgsql

--- a/blast/module.properties
+++ b/blast/module.properties
@@ -5,3 +5,4 @@ ManageVersion: false
 URL: https://github.com/BimberLab/DiscvrLabKeyModules
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/cluster/module.properties
+++ b/cluster/module.properties
@@ -5,3 +5,4 @@ URL: https://github.com/BimberLab/DiscvrLabKeyModules
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 ManageVersion: false
+SupportedDatabases: mssql, pgsql

--- a/discvrcore/module.properties
+++ b/discvrcore/module.properties
@@ -5,3 +5,4 @@ URL: https://github.com/BimberLab/DiscvrLabKeyModules
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 ManageVersion: false
+SupportedDatabases: mssql, pgsql

--- a/jbrowse/module.properties
+++ b/jbrowse/module.properties
@@ -5,3 +5,4 @@ Description: This module provides a wrapper about the JBrowse genome browser, in
 URL: https://github.com/BimberLab/DiscvrLabKeyModules
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/singlecell/module.properties
+++ b/singlecell/module.properties
@@ -5,3 +5,4 @@ URL: https://github.com/BimberLab/DiscvrLabKeyModules
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 ManageVersion: false
+SupportedDatabases: mssql, pgsql


### PR DESCRIPTION
#### Rationale
Need to explicitly declare support for SQL Server since we're about to change the default to PostgreSQL-only