### PR TITLE
No need to exclude Jakarta Activation API everywhere

### DIFF
--- a/SequenceAnalysis/build.gradle
+++ b/SequenceAnalysis/build.gradle
@@ -58,7 +58,6 @@ dependencies {
             {
                 // Exclude in favor of angus activation from API
                 exclude group: 'org.eclipse.angus', module: 'angus-activation'
-                exclude group: "jakarta.activation", module: "jakarta.activation-api"
             }
     )
 
@@ -76,7 +75,6 @@ dependencies {
             {
                 // Exclude in favor of angus activation from API
                 exclude group: 'org.eclipse.angus', module: 'angus-activation'
-                exclude group: "jakarta.activation", module: "jakarta.activation-api"
             }
     )
 


### PR DESCRIPTION
#### Rationale
Canonical version of Jakarta Activation API is now forced in `server/build.gradle`

#### Related Pull Requests
* https://github.com/LabKey/server/pull/937