### PR TITLE
Update BuildUtils method name

### DIFF
--- a/SequenceAnalysis/build.gradle
+++ b/SequenceAnalysis/build.gradle
@@ -161,7 +161,7 @@ dependencies {
 if (project.findProject(BuildUtils.getTestProjectPath(project.gradle)) != null && project.hasProperty("teamcity"))
 {
     project.evaluationDependsOn(BuildUtils.getTestProjectPath(project.gradle))
-    def configDir = new File(ServerDeployExtension.getServerDeployDirectory(project), "config")
+    def configDir = new File(ServerDeployExtension.getServerDeployDirectoryPath(project), "config")
     def testProject = project.findProject(BuildUtils.getTestProjectPath(project.gradle))
     def createPipelineConfigTask = project.tasks.register("createPipelineConfig", Copy) {
         Copy task ->


### PR DESCRIPTION
#### Rationale
Method name is changing in the related gradle plugins update for clarity.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/226

#### Changes
* `ServerDeployExtension.getServerDeployDirectory` -> `ServerDeployExtension.getServerDeployDirectoryPath`
