### PR TITLE
Fix JBrowseTest

### DIFF
--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/run/AbstractCommandWrapper.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/run/AbstractCommandWrapper.java
@@ -206,7 +206,7 @@ abstract public class AbstractCommandWrapper implements CommandWrapper
             String path = System.getenv("PATH");
 
             getLogger().debug("Existing PATH: " + path);
-            getLogger().debug("toolDir: " + path);
+            getLogger().debug("toolDir: " + toolDir);
 
 
             if (path == null)

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/run/AbstractCommandWrapper.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/run/AbstractCommandWrapper.java
@@ -204,6 +204,11 @@ abstract public class AbstractCommandWrapper implements CommandWrapper
         if (!StringUtils.isEmpty(toolDir))
         {
             String path = System.getenv("PATH");
+
+            getLogger().debug("Existing PATH: " + path);
+            getLogger().debug("toolDir: " + path);
+
+
             if (path == null)
             {
                 path = toolDir;

--- a/SequenceAnalysis/test/configs/pipelineConfig.xml
+++ b/SequenceAnalysis/test/configs/pipelineConfig.xml
@@ -4,6 +4,11 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
     <bean id="pipelineJobService" class="org.labkey.pipeline.api.PipelineJobServiceImpl">
+        <property name="appProperties">
+            <bean class="org.labkey.pipeline.api.properties.ApplicationPropertiesImpl">
+                <property name="toolsDirectory" value="@@SEQUENCEANALYSIS_TOOLS@@" />
+            </bean>
+        </property>
         <property name="configProperties">
             <bean class="org.labkey.pipeline.api.properties.ConfigPropertiesImpl">
                 <property name="softwarePackages">


### PR DESCRIPTION
#### Rationale
Set the default pipeline tool directory as well as the sequence tools-specific path



#### Changes
* Make sure that the code can find bgzip both when executed directly through `BgzipRunner` as well as invoked as part of a larger shell command through `SequencePipelineServiceImpl.sortROD()`