### PR TITLE
Don't configure `toolsDirectory` in the global `pipelineConfig.xml`

### DIFF
--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/run/AbstractCommandWrapper.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/run/AbstractCommandWrapper.java
@@ -204,6 +204,11 @@ abstract public class AbstractCommandWrapper implements CommandWrapper
         if (!StringUtils.isEmpty(toolDir))
         {
             String path = System.getenv("PATH");
+
+            getLogger().debug("Existing PATH: " + path);
+            getLogger().debug("toolDir: " + toolDir);
+
+
             if (path == null)
             {
                 path = toolDir;

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/run/AbstractCommandWrapper.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/run/AbstractCommandWrapper.java
@@ -204,11 +204,6 @@ abstract public class AbstractCommandWrapper implements CommandWrapper
         if (!StringUtils.isEmpty(toolDir))
         {
             String path = System.getenv("PATH");
-
-            getLogger().debug("Existing PATH: " + path);
-            getLogger().debug("toolDir: " + toolDir);
-
-
             if (path == null)
             {
                 path = toolDir;

--- a/SequenceAnalysis/test/configs/pipelineConfig.xml
+++ b/SequenceAnalysis/test/configs/pipelineConfig.xml
@@ -4,11 +4,6 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
     <bean id="pipelineJobService" class="org.labkey.pipeline.api.PipelineJobServiceImpl">
-        <property name="appProperties">
-            <bean class="org.labkey.pipeline.api.properties.ApplicationPropertiesImpl">
-                <property name="toolsDirectory" value="@@SEQUENCEANALYSIS_TOOLS@@" />
-            </bean>
-        </property>
         <property name="configProperties">
             <bean class="org.labkey.pipeline.api.properties.ConfigPropertiesImpl">
                 <property name="softwarePackages">


### PR DESCRIPTION
#### Rationale
The JBrowseTest failure was due to a test ordering issue. The test had an implicit dependency on another test that was customizing the pipeline tools directory via UI. The correct fix is to make `BaseWebDriverTest` responsible for customizing the pipeline tools if the `additional.pipeline.tools` property is configured.

#### Related Pull Requests
* Reverts: https://github.com/LabKey/DiscvrLabKeyModules/pull/330
* New fix: https://github.com/LabKey/testAutomation/pull/2224

#### Changes
* Don't configure `toolsDirectory` in the global `pipelineConfig.xml`
