### PR TITLE
Complete migration from srcURL and returnURL to returnUrl

### DIFF
--- a/SequenceAnalysis/resources/views/readsetDetails.html
+++ b/SequenceAnalysis/resources/views/readsetDetails.html
@@ -37,7 +37,7 @@ Ext4.onReady(function (){
                 text: 'More Actions',
                 menu: [{
                     text: 'Edit Details',
-                    href: LABKEY.ActionURL.buildURL('ldk', 'manageRecord', null, {schemaName: 'sequenceanalysis', queryName: 'sequence_readsets', keyField: 'rowid', key: readsetId}) + '&returnUrl=' + LDK.Utils.getSrcURL()
+                    href: LABKEY.ActionURL.buildURL('ldk', 'manageRecord', null, {schemaName: 'sequenceanalysis', queryName: 'sequence_readsets', keyField: 'rowid', key: readsetId}) + '&returnUrl=' + LDK.Utils.getReturnUrl()
                 }]
             }]
         }

--- a/SequenceAnalysis/resources/views/sequenceAnalysisDetails.html
+++ b/SequenceAnalysis/resources/views/sequenceAnalysisDetails.html
@@ -38,7 +38,7 @@ Ext4.onReady(function (){
                 text: 'More Actions',
                 menu: [{
                     text: 'Edit Analysis Details',
-                    href: LABKEY.ActionURL.buildURL('ldk', 'manageRecord', null, {schemaName: 'sequenceanalysis', queryName: 'sequence_analyses', keyField: 'rowid', key: analysisId}) + '&returnUrl=' + LDK.Utils.getSrcURL()
+                    href: LABKEY.ActionURL.buildURL('ldk', 'manageRecord', null, {schemaName: 'sequenceanalysis', queryName: 'sequence_analyses', keyField: 'rowid', key: analysisId}) + '&returnUrl=' + LDK.Utils.getReturnUrl()
                 }]
             }]
         }
@@ -94,7 +94,7 @@ Ext4.onReady(function (){
                         text: 'More Actions',
                         menu: [{
                             text: 'Edit Readset Details',
-                            href: LABKEY.ActionURL.buildURL('ldk', 'manageRecord', null, {schemaName: 'sequenceanalysis', queryName: 'sequence_readsets', keyField: 'rowid', key: row.readset}) + '&returnUrl=' + LDK.Utils.getSrcURL()
+                            href: LABKEY.ActionURL.buildURL('ldk', 'manageRecord', null, {schemaName: 'sequenceanalysis', queryName: 'sequence_readsets', keyField: 'rowid', key: row.readset}) + '&returnUrl=' + LDK.Utils.getReturnUrl()
                         }]
                     }]
                 }

--- a/SequenceAnalysis/resources/web/SequenceAnalysis/panel/IlluminaSampleExportPanel.js
+++ b/SequenceAnalysis/resources/web/SequenceAnalysis/panel/IlluminaSampleExportPanel.js
@@ -226,7 +226,7 @@ Ext4.define('SequenceAnalysis.panel.IlluminaSampleExportPanel', {
             },{
                 text: 'Cancel',
                 handler: function(btn){
-                    var url = LABKEY.ActionURL.getParameter('srcURL');
+                    var url = LABKEY.ActionURL.getParameter('returnUrl');
                     if (url)
                         window.location = decodeURIComponent(url);
                     else

--- a/SequenceAnalysis/resources/web/SequenceAnalysis/sequenceanalysisButtons.js
+++ b/SequenceAnalysis/resources/web/SequenceAnalysis/sequenceanalysisButtons.js
@@ -286,7 +286,7 @@ SequenceAnalysis.Buttons = new function(){
                 pks: checked,
                 schemaName: 'sequenceanalysis',
                 queryName: 'sequence_readsets',
-                srcURL: LDK.Utils.getSrcURL()
+                returnUrl: LDK.Utils.getReturnUrl()
             })
         },
 

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisController.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisController.java
@@ -924,7 +924,7 @@ public class SequenceAnalysisController extends SpringActionController
         @Override
         public @NotNull URLHelper getSuccessURL(DeleteForm form)
         {
-            URLHelper url = form.getReturnURLHelper();
+            URLHelper url = form.getReturnUrlHelper();
             return url != null ? url : _table.getGridURL(getContainer()) != null ? _table.getGridURL(getContainer()) : getContainer().getStartURL(getUser());
         }
     }


### PR DESCRIPTION
#### Rationale
In 2021 we made a major push to use `returnUrl` consistently instead of `srcURL` or `returnURL`. We can finish the job.

Issue 7580: inconsistent use of returnUrl parameter

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6407

#### Changes
- Change everything to `returnUrl` and get rid of code checking for old versions of the parameters