### PR TITLE
Eliminate org.labkey.api.util.Filter<T> in favor of Predicate<T>

### DIFF
--- a/jbrowse/src/org/labkey/jbrowse/JBrowseLuceneSearch.java
+++ b/jbrowse/src/org/labkey/jbrowse/JBrowseLuceneSearch.java
@@ -42,7 +42,6 @@ import org.labkey.api.jbrowse.JBrowseFieldDescriptor;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.security.User;
 import org.labkey.api.settings.AppProps;
-import org.labkey.api.util.Filter;
 import org.labkey.api.util.ShutdownListener;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.jbrowse.model.JBrowseSession;
@@ -62,6 +61,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -506,7 +506,7 @@ public class JBrowseLuceneSearch
         }
 
         @Override
-        public int removeUsingFilter(Filter<String> filter)
+        public int removeUsingFilter(Predicate<String> filter)
         {
             return _cache.removeUsingFilter(filter);
         }


### PR DESCRIPTION
#### Rationale
No need for a custom interface for basic filtering

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6507