### PR TITLE
Minor auto-refactor code cleanup on a massive scale

### DIFF
--- a/OpenLdapSync/src/org/labkey/openldapsync/OpenLdapSyncController.java
+++ b/OpenLdapSync/src/org/labkey/openldapsync/OpenLdapSyncController.java
@@ -57,7 +57,7 @@ public class OpenLdapSyncController extends SpringActionController
     }
 
     @RequiresPermission(AdminOperationsPermission.class)
-    public class InitiateLdapSyncAction extends MutatingApiAction<InitiateLdapSyncForm>
+    public static class InitiateLdapSyncAction extends MutatingApiAction<InitiateLdapSyncForm>
     {
         @Override
         public ApiResponse execute(InitiateLdapSyncForm form, BindException errors) throws Exception
@@ -100,7 +100,7 @@ public class OpenLdapSyncController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class ListLdapGroupsAction extends ReadOnlyApiAction<LdapForm>
+    public static class ListLdapGroupsAction extends ReadOnlyApiAction<LdapForm>
     {
         @Override
         public ApiResponse execute(LdapForm form, BindException errors) throws Exception
@@ -495,7 +495,7 @@ public class OpenLdapSyncController extends SpringActionController
     }
 
     @RequiresPermission(AdminOperationsPermission.class)
-    public class TestLdapConnectionAction extends MutatingApiAction<Object>
+    public static class TestLdapConnectionAction extends MutatingApiAction<Object>
     {
         @Override
         public ApiResponse execute(Object form, BindException errors) throws Exception
@@ -545,7 +545,7 @@ public class OpenLdapSyncController extends SpringActionController
     }
 
     @RequiresPermission(AdminOperationsPermission.class)
-    public class GetLdapSettingsAction extends ReadOnlyApiAction<Object>
+    public static class GetLdapSettingsAction extends ReadOnlyApiAction<Object>
     {
         @Override
         public ApiResponse execute(Object form, BindException errors)
@@ -569,7 +569,7 @@ public class OpenLdapSyncController extends SpringActionController
 
     @Marshal(Marshaller.Jackson)
     @RequiresPermission(AdminOperationsPermission.class)
-    public class SetLdapSettingsAction extends MutatingApiAction<LdapForm>
+    public static class SetLdapSettingsAction extends MutatingApiAction<LdapForm>
     {
         @Override
         public ApiResponse execute(LdapForm form, BindException errors)
@@ -668,7 +668,7 @@ public class OpenLdapSyncController extends SpringActionController
             if (form.getSyncMode() != null)
                 props.put(LdapSettings.SYNC_MODE_PROP, form.getSyncMode());
 
-            if (form.getAllowedDn() != null && form.getAllowedDn().length() > 0)
+            if (form.getAllowedDn() != null && !form.getAllowedDn().isEmpty())
             {
                 String allowed = StringUtils.join(form.getAllowedDn().toList(), LdapSettings.DELIM);
                 props.put(LdapSettings.ALLOWED_DN_PROP, allowed);

--- a/OpenLdapSync/src/org/labkey/openldapsync/ldap/LdapEntry.java
+++ b/OpenLdapSync/src/org/labkey/openldapsync/ldap/LdapEntry.java
@@ -76,7 +76,7 @@ public class LdapEntry
         try
         {
             int value = Integer.parseInt(a);
-            return ((int) value & 2) == 0;
+            return (value & 2) == 0;
         }
         catch (NumberFormatException e)
         {

--- a/OpenLdapSync/src/org/labkey/openldapsync/ldap/LdapEntry.java
+++ b/OpenLdapSync/src/org/labkey/openldapsync/ldap/LdapEntry.java
@@ -75,8 +75,8 @@ public class LdapEntry
 
         try
         {
-            Integer value = Integer.parseInt(a);
-            return (value.intValue() & 2) == 0;
+            int value = Integer.parseInt(a);
+            return ((int) value & 2) == 0;
         }
         catch (NumberFormatException e)
         {

--- a/OpenLdapSync/src/org/labkey/openldapsync/ldap/LdapSettings.java
+++ b/OpenLdapSync/src/org/labkey/openldapsync/ldap/LdapSettings.java
@@ -466,7 +466,6 @@ public class LdapSettings
 
     /**
      * Provides a brief sanity check of the settings, designed to identify problems if a sync will run.
-     * @throws LdapException
      */
     public void validateSettings() throws LdapException
     {
@@ -495,7 +494,7 @@ public class LdapSettings
 
         if (LdapSyncMode.groupWhitelist.equals(mode))
         {
-            if (getGroupWhiteList().size() == 0)
+            if (getGroupWhiteList().isEmpty())
             {
                 throw new LdapException("Cannot choose to sync based on specific groups unless you provide a list of groups to sync");
             }

--- a/OpenLdapSync/src/org/labkey/openldapsync/ldap/LdapSyncRunner.java
+++ b/OpenLdapSync/src/org/labkey/openldapsync/ldap/LdapSyncRunner.java
@@ -14,7 +14,6 @@ import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.RuntimeSQLException;
-import org.labkey.api.data.Selector;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
@@ -1058,7 +1057,7 @@ public class LdapSyncRunner implements Job
         }
 
         // This can be used to return LdapEntry objects to support some degree of automated testing without needing a functional LDAP Server
-        public class DummyConnectionWrapper extends LdapConnectionWrapper
+        public static class DummyConnectionWrapper extends LdapConnectionWrapper
         {
             private final List<LdapEntry> _users = new ArrayList<>();
             private final Map<String, MockLdapEntry> _groupMap = new HashMap<>();

--- a/QueryExtensions/src/org/labkey/queryextensions/QueryExtensionsController.java
+++ b/QueryExtensions/src/org/labkey/queryextensions/QueryExtensionsController.java
@@ -16,14 +16,7 @@
 
 package org.labkey.queryextensions;
 
-import org.labkey.api.action.SimpleViewAction;
 import org.labkey.api.action.SpringActionController;
-import org.labkey.api.security.RequiresPermission;
-import org.labkey.api.security.permissions.ReadPermission;
-import org.labkey.api.view.JspView;
-import org.labkey.api.view.NavTree;
-import org.springframework.validation.BindException;
-import org.springframework.web.servlet.ModelAndView;
 
 public class QueryExtensionsController extends SpringActionController
 {

--- a/QueryExtensions/test/src/org/labkey/test/tests/queryextensions/QueryExtensionsTest.java
+++ b/QueryExtensions/test/src/org/labkey/test/tests/queryextensions/QueryExtensionsTest.java
@@ -39,7 +39,7 @@ public class QueryExtensionsTest extends BaseWebDriverTest
     @BeforeClass
     public static void setupProject()
     {
-        QueryExtensionsTest init = (QueryExtensionsTest)getCurrentTest();
+        QueryExtensionsTest init = getCurrentTest();
 
         init.doSetup();
     }

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/GenomeTrigger.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/GenomeTrigger.java
@@ -16,7 +16,6 @@
 package org.labkey.api.sequenceanalysis;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.labkey.api.data.Container;
 import org.labkey.api.security.User;
 

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/SequenceAnalysisService.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/SequenceAnalysisService.java
@@ -113,10 +113,10 @@ abstract public class SequenceAnalysisService
 
     abstract public void registerReadsetListener(ReadsetListener listener);
 
-    public static interface ReadsetListener
+    public interface ReadsetListener
     {
-        public void onReadsetCreate(User u, Readset rs, @Nullable Readset replacedReadset, @Nullable PipelineJob job);
+        void onReadsetCreate(User u, Readset rs, @Nullable Readset replacedReadset, @Nullable PipelineJob job);
 
-        public boolean isAvailable(Container c, User u);
+        boolean isAvailable(Container c, User u);
     }
 }

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/AbstractPipelineStepProvider.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/AbstractPipelineStepProvider.java
@@ -20,7 +20,6 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.labkey.api.view.template.ClientDependency;
 
-import java.lang.reflect.ParameterizedType;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -39,7 +38,7 @@ abstract public class AbstractPipelineStepProvider<StepType extends PipelineStep
     private final String _websiteURL;
     private final String _description;
     private final LinkedHashSet<String> _clientDependencyPaths;
-    private List<ToolParameterDescriptor> _parameters;
+    private final List<ToolParameterDescriptor> _parameters;
 
     public AbstractPipelineStepProvider(String name, String label, @Nullable String toolName, String description, @Nullable List<ToolParameterDescriptor> parameters, @Nullable Collection<String> clientDependencyPaths, @Nullable String websiteURL)
     {

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/AlignerIndexUtil.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/AlignerIndexUtil.java
@@ -1,17 +1,13 @@
 package org.labkey.api.sequenceanalysis.pipeline;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ConvertHelper;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.pipeline.WorkDirectory;
-import org.labkey.api.sequenceanalysis.run.SimpleScriptWrapper;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 
 /**
  * Created by bimber on 9/6/2014.

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/AlignmentStep.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/AlignmentStep.java
@@ -35,7 +35,6 @@ public interface AlignmentStep extends PipelineStep
 {
     /**
      * Creates any indexes needed by this aligner if not already present.
-     * @throws PipelineJobException
      */
     IndexOutput createIndex(ReferenceGenome referenceGenome, File outputDir) throws PipelineJobException;
 
@@ -49,7 +48,6 @@ public interface AlignmentStep extends PipelineStep
      * @param inputFastqs1 The forward FASTQ file(s). In most cases this is a single FASTQ. The aligner must return true for canAlignMultiplePairsAtOnce() otherwise.
      * @param inputFastqs2 The second FASTQ(s), if using paired end data
      * @param basename The basename to use as the output
-     * @throws PipelineJobException
      */
     AlignmentOutput performAlignment(Readset rs, List<File> inputFastqs1, @Nullable List<File> inputFastqs2, File outputDirectory, ReferenceGenome referenceGenome, String basename, String readGroupId, @Nullable String platformUnit) throws PipelineJobException;
 
@@ -102,7 +100,6 @@ public interface AlignmentStep extends PipelineStep
     /**
      * Optional.  Allows this analysis to gather any information from the server required to execute the alignment.  This information needs to be serialized
      * to run remotely, which could be as simple as writing to a text file.
-     * @throws PipelineJobException
      */
     default void init(SequenceAnalysisJobSupport support) throws PipelineJobException
     {

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/AnalysisStep.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/AnalysisStep.java
@@ -31,7 +31,6 @@ public interface AnalysisStep extends PipelineStep
     /**
      * Optional.  Allows this analysis to gather any information from the server required to execute the analysis.  This information needs to be serialized
      * to run remotely, which could be as simple as writing to a text file.
-     * @throws PipelineJobException
      */
     default void init(SequenceAnalysisJobSupport support) throws PipelineJobException
     {

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/AssemblyStep.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/AssemblyStep.java
@@ -3,7 +3,6 @@ package org.labkey.api.sequenceanalysis.pipeline;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.model.Readset;
-import org.labkey.api.util.Pair;
 
 import java.io.File;
 

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/CommandLineParam.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/CommandLineParam.java
@@ -29,7 +29,7 @@ import java.util.List;
 public class CommandLineParam
 {
     private final String _argName;
-    protected boolean _isSwitch = false;
+    protected boolean _isSwitch;
 
     private CommandLineParam(String argName, boolean isSwitch)
     {

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/PipelineOutputTracker.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/PipelineOutputTracker.java
@@ -9,7 +9,6 @@ public interface PipelineOutputTracker
 {
     /**
      * Add an intermediate file.  If the user selected 'delete intermediates', this will be deleted on job success.
-     * @param file
      */
     void addIntermediateFile(File file);
 
@@ -17,13 +16,6 @@ public interface PipelineOutputTracker
 
     /**
      * Add a SequenceOutputFile for this job.  These files are tracked and displayed through the browser UI.
-     * @param file
-     * @param label
-     * @param category
-     * @param readsetId
-     * @param analysisId
-     * @param genomeId
-     * @param description
      */
     void addSequenceOutput(File file, String label, String category, @Nullable Integer readsetId, @Nullable Integer analysisId, @Nullable Integer genomeId, @Nullable String description);
 

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/PipelineStepOutput.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/PipelineStepOutput.java
@@ -16,7 +16,6 @@
 package org.labkey.api.sequenceanalysis.pipeline;
 
 import org.jetbrains.annotations.Nullable;
-import org.labkey.api.sequenceanalysis.model.Readset;
 import org.labkey.api.util.Pair;
 
 import java.io.File;
@@ -34,15 +33,11 @@ public interface PipelineStepOutput extends PipelineOutputTracker
 {
     /**
      * Add an experiment input to this pipeline step
-     * @param input
-     * @param role
      */
     void addInput(File input, String role);
 
     /**
      * Add an experiment output to this pipeline step
-     * @param output
-     * @param role
      */
     void addOutput(File output, String role);
 
@@ -65,8 +60,6 @@ public interface PipelineStepOutput extends PipelineOutputTracker
     /**
      * Add an intermediate file.  If the user selected 'delete intermediates', this will be deleted on job success.
      * This will also be recorded as a step output with this role.
-     * @param file
-     * @param role
      */
     void addIntermediateFile(File file, String role);
 

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/ProcessUtils.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/ProcessUtils.java
@@ -3,7 +3,6 @@ package org.labkey.api.sequenceanalysis.pipeline;
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.labkey.api.util.StringUtilsLabKey;
 
 import java.io.BufferedInputStream;

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/SamtoolsIndexer.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/SamtoolsIndexer.java
@@ -1,7 +1,6 @@
 package org.labkey.api.sequenceanalysis.pipeline;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.labkey.api.pipeline.PipelineJobException;
 
 import java.io.File;

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/SamtoolsRunner.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/SamtoolsRunner.java
@@ -1,7 +1,6 @@
 package org.labkey.api.sequenceanalysis.pipeline;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.sequenceanalysis.run.AbstractCommandWrapper;
 

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/SequenceOutputHandler.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/SequenceOutputHandler.java
@@ -136,7 +136,6 @@ public interface SequenceOutputHandler<T>
 
     /**
      * Provides the opportunity for the handler to validate parameters prior to running
-     * @param params
      * @return List of error messages.  Null or empty list indicates no errors.
      */
     default List<String> validateParameters(List<SequenceOutputFile> outputFiles, JSONObject params)
@@ -174,8 +173,6 @@ public interface SequenceOutputHandler<T>
          * Allows handlers to perform setup on the webserver prior to remote running.  This will be run in the background as a pipeline job.
          * @param ctx Provides context about the active pipeline job
          * @param inputFiles      The list of input files to process
-         * @param actions
-         * @param outputsToCreate
          */
         default void init(JobContext ctx, List<SequenceOutputFile> inputFiles, List<RecordedAction> actions, List<SequenceOutputFile> outputsToCreate) throws UnsupportedOperationException, PipelineJobException
         {
@@ -189,10 +186,6 @@ public interface SequenceOutputHandler<T>
          *
          * @param support Provides context about the active pipeline job
          * @param inputFiles The list of input files to process
-         * @param params
-         * @param outputDir
-         * @param actions
-         * @param outputsToCreate
          */
         void processFilesOnWebserver(PipelineJob job, SequenceAnalysisJobSupport support, List<SequenceOutputFile> inputFiles, JSONObject params, File outputDir, List<RecordedAction> actions, List<SequenceOutputFile> outputsToCreate) throws UnsupportedOperationException, PipelineJobException;
 
@@ -211,10 +204,6 @@ public interface SequenceOutputHandler<T>
          * @param job             The pipeline job running this task
          * @param support Provides context about the active pipeline job
          * @param readsets      The list of readsets to process
-         * @param params
-         * @param outputDir
-         * @param actions
-         * @param outputsToCreate
          */
         void init(PipelineJob job, SequenceAnalysisJobSupport support, List<Readset> readsets, JSONObject params, File outputDir, List<RecordedAction> actions, List<SequenceOutputFile> outputsToCreate) throws UnsupportedOperationException, PipelineJobException;
 
@@ -222,10 +211,6 @@ public interface SequenceOutputHandler<T>
          *
          * @param support Provides context about the active pipeline job
          * @param readsets The list of readsets to process
-         * @param params
-         * @param outputDir
-         * @param actions
-         * @param outputsToCreate
          */
         void processFilesOnWebserver(PipelineJob job, SequenceAnalysisJobSupport support, List<Readset> readsets, JSONObject params, File outputDir, List<RecordedAction> actions, List<SequenceOutputFile> outputsToCreate) throws UnsupportedOperationException, PipelineJobException;
 

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/SequencePipelineService.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/SequencePipelineService.java
@@ -129,11 +129,6 @@ abstract public class SequencePipelineService
 
     /**
      *
-     * @param input
-     * @param log
-     * @param startColumnIdx The 1-based column on which to sort.  BED files are 2 and GTF/GFF are 4
-     * @throws IOException
-     * @throws PipelineJobException
      */
     abstract public void sortROD(File input, Logger log, Integer startColumnIdx) throws IOException, PipelineJobException;
 

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/SortSamWrapper.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/SortSamWrapper.java
@@ -4,7 +4,6 @@ import htsjdk.samtools.SAMFileHeader;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.run.PicardWrapper;

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/TaskFileManager.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/TaskFileManager.java
@@ -56,7 +56,7 @@ public interface TaskFileManager extends PipelineOutputTracker
 
     boolean isDeleteIntermediateFiles();
 
-    public boolean performCleanupAfterEachStep();
+    boolean performCleanupAfterEachStep();
 
     boolean isCopyInputsLocally();
 

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/ToolParameterDescriptor.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/ToolParameterDescriptor.java
@@ -27,7 +27,6 @@ import org.labkey.api.pipeline.PipelineJobException;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * User: bimber

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/run/AbstractCommandWrapper.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/run/AbstractCommandWrapper.java
@@ -43,7 +43,7 @@ abstract public class AbstractCommandWrapper implements CommandWrapper
 {
     private File _outputDir = null;
     private File _workingDir = null;
-    private Logger _log = null;
+    private Logger _log;
     private Level _logLevel = Level.DEBUG;
     private boolean _warnNonZeroExits = true;
     private boolean _throwNonZeroExits = true;
@@ -221,7 +221,7 @@ abstract public class AbstractCommandWrapper implements CommandWrapper
             // If the command has a path, then prepend its parent directory to the PATH
             // environment variable as well.
             String exePath = pb.command().get(0);
-            if (exePath != null && !"".equals(exePath) && exePath.indexOf(File.separatorChar) != -1)
+            if (exePath != null && !exePath.isEmpty() && exePath.indexOf(File.separatorChar) != -1)
             {
                 File fileExe = new File(exePath);
                 String exeDir = fileExe.getParent();

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/run/AbstractDiscvrSeqWrapper.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/run/AbstractDiscvrSeqWrapper.java
@@ -1,7 +1,6 @@
 package org.labkey.api.sequenceanalysis.run;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 public class AbstractDiscvrSeqWrapper extends AbstractGatk4Wrapper
 {

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/run/AbstractGatkWrapper.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/run/AbstractGatkWrapper.java
@@ -1,10 +1,6 @@
 package org.labkey.api.sequenceanalysis.run;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.math3.exception.ConvergenceException;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
-import org.labkey.api.data.ConvertHelper;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.pipeline.PipelineJobService;
 import org.labkey.api.sequenceanalysis.SequenceAnalysisService;

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/run/CommandWrapper.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/run/CommandWrapper.java
@@ -30,8 +30,6 @@ public interface CommandWrapper
     /**
      *
      * @param params A list of params used to create the command.  This will be passed directly to ProcessBuilder()
-     * @return The output of this command.
-     * @throws PipelineJobException
      */
     void execute(List<String> params) throws PipelineJobException;
 

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/run/GeneToNameTranslator.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/run/GeneToNameTranslator.java
@@ -1,7 +1,6 @@
 package org.labkey.api.sequenceanalysis.run;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.reader.Readers;
 import org.labkey.api.util.FileUtil;

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/run/PicardWrapper.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/run/PicardWrapper.java
@@ -3,10 +3,8 @@ package org.labkey.api.sequenceanalysis.run;
 import htsjdk.samtools.ValidationStringency;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
-import org.labkey.api.pipeline.PipelineJobService;
 import org.labkey.api.sequenceanalysis.pipeline.SequencePipelineService;
 
 import java.io.File;

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/run/SelectVariantsWrapper.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/run/SelectVariantsWrapper.java
@@ -1,7 +1,6 @@
 package org.labkey.api.sequenceanalysis.run;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.labkey.api.pipeline.PipelineJobException;
 
 import java.io.File;

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/run/SimpleScriptWrapper.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/run/SimpleScriptWrapper.java
@@ -1,7 +1,6 @@
 package org.labkey.api.sequenceanalysis.run;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 
 /**

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/run/VariantFiltrationWrapper.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/run/VariantFiltrationWrapper.java
@@ -1,7 +1,6 @@
 package org.labkey.api.sequenceanalysis.run;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.labkey.api.pipeline.PipelineJobException;
 
 import java.io.File;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/FileGroup.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/FileGroup.java
@@ -3,7 +3,6 @@ package org.labkey.sequenceanalysis;
 import java.io.File;
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/OutputIntegrationTests.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/OutputIntegrationTests.java
@@ -23,13 +23,11 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExperimentService;
-import org.labkey.api.laboratory.LaboratoryService;
 import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.pipeline.PipelineJobService;
 import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
-import org.labkey.api.sequenceanalysis.SequenceAnalysisService;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.TestContext;
@@ -149,7 +147,7 @@ public class OutputIntegrationTests
                 throw new RuntimeException("Problem creating pipeline job: " + responseJson.getString("exception"));
 
             JSONArray guidList = responseJson.getJSONArray("jobGUIDs");
-            assert guidList.length() >= 1;
+            assert !guidList.isEmpty();
 
             Set<PipelineJob> ret = new HashSet<>();
             for (int i = 0; i < guidList.length(); i++)

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisController.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisController.java
@@ -311,7 +311,7 @@ public class SequenceAnalysisController extends SpringActionController
                 }
             }
 
-            if (files.size() == 0)
+            if (files.isEmpty())
             {
                 return HtmlView.of("Error: either no files provided or the files did not exist on the server");
             }
@@ -1100,7 +1100,7 @@ public class SequenceAnalysisController extends SpringActionController
                     }
                 }
 
-                if (datas.size() > 0)
+                if (!datas.isEmpty())
                 {
                     for (ExpData d : datas)
                     {
@@ -2910,7 +2910,7 @@ public class SequenceAnalysisController extends SpringActionController
                 public void exec(ResultSet object) throws SQLException
                 {
                     Results rs = new ResultsImpl(object, cols);
-                    Integer rowId = rs.getInt(FieldKey.fromString("rowid"));
+                    int rowId = rs.getInt(FieldKey.fromString("rowid"));
                     String header = se.eval(rs.getFieldKeyRowMap());
                     RefNtSequenceModel model = new RefNtSequenceModel();
                     if (rs.getObject(FieldKey.fromString("sequenceFile")) != null)
@@ -2920,7 +2920,7 @@ public class SequenceAnalysisController extends SpringActionController
 
                     try
                     {
-                        if (intervalMap.has(rowId.toString()))
+                        if (intervalMap.has(Integer.toString(rowId)))
                         {
                             String wholeSequence = model.getSequence();
                             if (wholeSequence == null)
@@ -2929,7 +2929,7 @@ public class SequenceAnalysisController extends SpringActionController
                                 return;
                             }
 
-                            for (String t : intervalMap.getString(rowId.toString()).split(","))
+                            for (String t : intervalMap.getString(Integer.toString(rowId)).split(","))
                             {
                                 String[] coordinates = t.split("-");
                                 if (coordinates.length != 2)
@@ -3396,7 +3396,7 @@ public class SequenceAnalysisController extends SpringActionController
             }
         }
 
-        if (resourceSettings.length() > 0)
+        if (!resourceSettings.isEmpty())
         {
             JSONObject json = new JSONObject();
             json.put("name", "resourceSettings");
@@ -4487,9 +4487,9 @@ public class SequenceAnalysisController extends SpringActionController
 
         private static SequenceMatch doCheck(String name, String seq, String refSeq, RefNtSequenceModel match, DNASequence fastaSequence, boolean isRC)
         {
-            boolean sequencesMatch = refSeq.length() > 0 && seq.length() > 0 && seq.equals(refSeq);
-            boolean fastaSequenceIsSubsetOfReference = refSeq.length() > 0 && seq.length() > 0 && refSeq.contains(seq);
-            boolean referenceSequenceIsSubsetOfFasta = refSeq.length() > 0 && seq.length() > 0 && seq.contains(refSeq);
+            boolean sequencesMatch = !refSeq.isEmpty() && !seq.isEmpty() && seq.equals(refSeq);
+            boolean fastaSequenceIsSubsetOfReference = !refSeq.isEmpty() && !seq.isEmpty() && refSeq.contains(seq);
+            boolean referenceSequenceIsSubsetOfFasta = !refSeq.isEmpty() && !seq.isEmpty() && seq.contains(refSeq);
 
             if (name.equals(match.getName()) || sequencesMatch || fastaSequenceIsSubsetOfReference || referenceSequenceIsSubsetOfFasta)
             {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisManager.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisManager.java
@@ -82,7 +82,6 @@ import java.io.InputStream;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -162,7 +161,7 @@ public class SequenceAnalysisManager
         {
             _platforms = new ArrayList<>();
             TableSelector ts = new TableSelector(SequenceAnalysisSchema.getInstance().getSchema().getTable(SequenceAnalysisSchema.TABLE_SEQUENCE_PLATFORMS));
-            ts.forEach(new TableSelector.ForEachBlock<ResultSet>()
+            ts.forEach(new TableSelector.ForEachBlock<>()
             {
                 @Override
                 public void exec(ResultSet rs) throws SQLException

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisModule.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisModule.java
@@ -510,17 +510,17 @@ public class SequenceAnalysisModule extends ExtendedSimpleModule
     public Set<Class> getIntegrationTests()
     {
         @SuppressWarnings({"unchecked"})
-        Set<Class> testClasses = new HashSet<Class>(Arrays.asList(
-            Barcoder.TestCase.class,
-            BamIterator.TestCase.class,
-            SequenceIntegrationTests.SequenceImportPipelineTestCase.class,
-            //SequenceIntegrationTests.SequenceAnalysisPipelineTestCase3.class,
-            SequenceIntegrationTests.SequenceAnalysisPipelineTestCase1.class,
-            SequenceIntegrationTests.SequenceAnalysisPipelineTestCase2.class,
-            OutputIntegrationTests.VariantProcessingTest.class,
-            SequenceRemoteIntegrationTests.class,
-            SequenceTriggerHelper.TestCase.class,
-            SequencePipelineServiceImpl.TestCase.class
+        Set<Class> testClasses = new HashSet<>(Arrays.asList(
+                Barcoder.TestCase.class,
+                BamIterator.TestCase.class,
+                SequenceIntegrationTests.SequenceImportPipelineTestCase.class,
+                //SequenceIntegrationTests.SequenceAnalysisPipelineTestCase3.class,
+                SequenceIntegrationTests.SequenceAnalysisPipelineTestCase1.class,
+                SequenceIntegrationTests.SequenceAnalysisPipelineTestCase2.class,
+                OutputIntegrationTests.VariantProcessingTest.class,
+                SequenceRemoteIntegrationTests.class,
+                SequenceTriggerHelper.TestCase.class,
+                SequencePipelineServiceImpl.TestCase.class
         ));
 
         return testClasses;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisSchema.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisSchema.java
@@ -18,7 +18,6 @@ package org.labkey.sequenceanalysis;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.data.TableInfo;
-import org.labkey.api.data.dialect.SqlDialect;
 
 public class SequenceAnalysisSchema
 {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceIntegrationTests.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceIntegrationTests.java
@@ -509,7 +509,7 @@ public class SequenceIntegrationTests
                 throw new RuntimeException("Problem creating pipeline job: " + responseJson.getString("exception"));
 
             JSONArray guidList = responseJson.getJSONArray("jobGUIDs");
-            assert guidList.length() >= 1;
+            assert !guidList.isEmpty();
 
             Set<PipelineJob> ret = new HashSet<>();
             for (int i = 0; i < guidList.length(); i++)
@@ -763,7 +763,6 @@ public class SequenceIntegrationTests
         /**
          * This is the most basic test of readset import and creation.  A single FASTQ is provided, which can be normalized on the webserver
          * without external tools.
-         * @throws Exception
          */
         @Test
         public void basicTest() throws Exception
@@ -909,7 +908,7 @@ public class SequenceIntegrationTests
             waitForJobs(jobsUnsorted);
 
             List<PipelineJob> jobs = new ArrayList<>(jobsUnsorted);
-            Collections.sort(jobs, new Comparator<PipelineJob>()
+            Collections.sort(jobs, new Comparator<>()
             {
                 @Override
                 public int compare(PipelineJob o1, PipelineJob o2)
@@ -1005,7 +1004,6 @@ public class SequenceIntegrationTests
         /**
          * This test takes 2 input files: a FASTQ and an SFF.  The SFF should be converted to FASTQ, and the files merged into a single
          * FASTQ output.  This pipeline is configured to retain intermediate files.
-         * @throws Exception
          */
         @Test
         public void mergeTest() throws Exception
@@ -1022,7 +1020,6 @@ public class SequenceIntegrationTests
 
         /**
          * This is a variation on mergeTest, except intermediate files are deleting and input file are compressed.
-         * @throws Exception
          */
         @Test
         public void mergeTestDeletingIntermediates() throws Exception
@@ -1104,7 +1101,6 @@ public class SequenceIntegrationTests
 
         /**
          * This test uses a barcoded input
-         * @throws Exception
          */
         @Test
         public void barcodeTest() throws Exception
@@ -1151,7 +1147,6 @@ public class SequenceIntegrationTests
 
         /**
          * This is an extension of barcodeTest(), except intermediate files are deleted and inputs compressed
-         * @throws Exception
          */
         @Test
         public void barcodeTestDeletingIntermediates() throws Exception
@@ -1211,7 +1206,6 @@ public class SequenceIntegrationTests
 
         /**
          * This imports a readset from two paired end inputs
-         * @throws Exception
          */
         @Test
         public void pairedEndTest() throws Exception
@@ -1260,7 +1254,6 @@ public class SequenceIntegrationTests
 
         /**
          * An extension of pairedEndTest(), except input files are moved to the analysis folder
-         * @throws Exception
          */
         @Test
         public void pairedEndTestMovingInputs() throws Exception
@@ -1317,7 +1310,6 @@ public class SequenceIntegrationTests
 
         /**
          * An extension of pairedEndTest(), except input files are deleted on completion
-         * @throws Exception
          */
         @Test
         public void pairedEndTestDeletingInputs() throws Exception
@@ -1684,7 +1676,7 @@ public class SequenceIntegrationTests
                 }
             }
 
-            return files.toArray(new String[files.size()]);
+            return files.toArray(new String[0]);
         }
 
         protected void appendSamplesForAlignment(JSONObject config, List<SequenceReadsetImpl> readsets)
@@ -1818,6 +1810,7 @@ public class SequenceIntegrationTests
             doCleanup(PROJECT_NAME);
         }
 
+        @Override
         protected String getProjectName()
         {
             return PROJECT_NAME;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceOutputsNavItem.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceOutputsNavItem.java
@@ -89,7 +89,7 @@ public class SequenceOutputsNavItem extends AbstractNavItem implements SummaryNa
             SQLFragment sql = new SQLFragment("SELECT t.category, count(*) as total FROM ").append(ti.getFromSQL("t")).append(" GROUP BY t.category");
             SqlSelector ss = new SqlSelector(ti.getSchema(), sql);
             final TreeMap<String, Long> categories = new TreeMap<>();
-            ss.forEach(new Selector.ForEachBlock<ResultSet>()
+            ss.forEach(new Selector.ForEachBlock<>()
             {
                 @Override
                 public void exec(ResultSet object) throws SQLException

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/AbstractCombineGeneCountsHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/AbstractCombineGeneCountsHandler.java
@@ -230,7 +230,7 @@ abstract public class AbstractCombineGeneCountsHandler extends AbstractParameter
         action.setStartTime(new Date());
 
         String name = params.getString("name");
-        Boolean doSkipGenesWithoutData = params.optBoolean("skipGenesWithoutData", false);
+        boolean doSkipGenesWithoutData = params.optBoolean("skipGenesWithoutData", false);
         ctx.getLogger().debug("skip genes without data: " + doSkipGenesWithoutData);
 
         int gtf = params.optInt("gtf");

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/BamHaplotypeHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/BamHaplotypeHandler.java
@@ -105,7 +105,7 @@ public class BamHaplotypeHandler implements SequenceOutputHandler<SequenceOutput
         return false;
     }
 
-    public class Processor implements SequenceOutputProcessor
+    public static class Processor implements SequenceOutputProcessor
     {
         @Override
         public void processFilesRemote(List<SequenceOutputFile> inputFiles, JobContext ctx) throws UnsupportedOperationException, PipelineJobException

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/CombineSubreadGeneCountsHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/CombineSubreadGeneCountsHandler.java
@@ -76,7 +76,7 @@ public class CombineSubreadGeneCountsHandler extends AbstractCombineGeneCountsHa
 
                     results.distinctGenes.add(geneId);
 
-                    Double count = Double.parseDouble(cells[6]);
+                    double count = Double.parseDouble(cells[6]);
 
                     Map<String, Double> countMap = results.counts.get(so.getRowid());
                     if (countMap == null)

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/CompareVariantsHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/CompareVariantsHandler.java
@@ -18,7 +18,6 @@ import org.labkey.api.view.ActionURL;
 import org.labkey.sequenceanalysis.SequenceAnalysisModule;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 
@@ -106,7 +105,7 @@ public class CompareVariantsHandler implements SequenceOutputHandler<SequenceOut
         return false;
     }
 
-    public class Processor implements SequenceOutputProcessor
+    public static class Processor implements SequenceOutputProcessor
     {
         @Override
         public void processFilesOnWebserver(PipelineJob job, SequenceAnalysisJobSupport support, List<SequenceOutputFile> inputFiles, JSONObject params, File outputDir, List<RecordedAction> actions, List<SequenceOutputFile> outputsToCreate) throws UnsupportedOperationException, PipelineJobException

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/GenotypeGVCFHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/GenotypeGVCFHandler.java
@@ -673,8 +673,8 @@ public class GenotypeGVCFHandler implements SequenceOutputHandler<SequenceOutput
 
                 // See: https://gatk.broadinstitute.org/hc/en-us/articles/4418054384027-GenotypeGVCFs#--genomicsdb-max-alternate-alleles
                 // "A typical value is 3 more than the --max-alternate-alleles value that's used by GenotypeGVCFs and larger differences result in more robustness to PCR-related indel errors"
-                Integer maxAlt = ctx.getParams().getInt("variantCalling.GenotypeGVCFs.max_alternate_alleles") + 3;
-                toolParams.add(maxAlt.toString());
+                int maxAlt = ctx.getParams().getInt("variantCalling.GenotypeGVCFs.max_alternate_alleles") + 3;
+                toolParams.add(Integer.toString(maxAlt));
             }
 
             if (ctx.getParams().optBoolean("variantCalling.GenotypeGVCFs.includeNonVariantSites"))

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/LiftoverHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/LiftoverHandler.java
@@ -138,7 +138,7 @@ public class LiftoverHandler implements SequenceOutputHandler<SequenceOutputHand
 
     private static String getOutputExtension(File inputFile)
     {
-        String ext = null;
+        String ext;
         if (_bedFileType.isType(inputFile))
         {
             ext = ".bed";
@@ -172,7 +172,7 @@ public class LiftoverHandler implements SequenceOutputHandler<SequenceOutputHand
         @Override
         public void init(JobContext ctx, List<SequenceOutputFile> inputFiles, List<RecordedAction> actions, List<SequenceOutputFile> outputsToCreate) throws UnsupportedOperationException, PipelineJobException
         {
-            Integer chainFileId = ctx.getParams().getInt("chainFileId");
+            int chainFileId = ctx.getParams().getInt("chainFileId");
             ExpData chainData = ExperimentService.get().getExpData(chainFileId);
             if (chainData == null || !chainData.getFile().exists())
             {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/MultiQCBamHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/MultiQCBamHandler.java
@@ -20,7 +20,6 @@ import org.labkey.sequenceanalysis.run.MultiQcRunner;
 import org.labkey.sequenceanalysis.util.SequenceUtil;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/MultiQCHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/MultiQCHandler.java
@@ -20,7 +20,6 @@ import org.labkey.sequenceanalysis.run.util.FastqcRunner;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/SbtGeneCountHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/SbtGeneCountHandler.java
@@ -17,7 +17,6 @@ import org.labkey.api.view.ActionURL;
 import org.labkey.sequenceanalysis.SequenceAnalysisModule;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/UnmappedSequenceBasedGenotypeHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/UnmappedSequenceBasedGenotypeHandler.java
@@ -35,7 +35,6 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -95,7 +94,7 @@ public class UnmappedSequenceBasedGenotypeHandler extends AbstractParameterizedO
         {
             String[] tokens = header.split("-");
 
-            Integer count = Integer.parseInt(tokens[tokens.length - 1]);
+            int count = Integer.parseInt(tokens[tokens.length - 1]);
             Integer c = _sampleMap.getOrDefault(sampleName, 0);
             c += count;
             _totalReads += count;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/api/picard/CigarPositionIterable.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/api/picard/CigarPositionIterable.java
@@ -139,7 +139,7 @@ public class CigarPositionIterable implements Iterable<CigarPositionIterable.Pos
      * Describes a specific position in an alignment, including the position relative to the start of both the reference and read
      * sequences.
      */
-    public class PositionInfo
+    public static class PositionInfo
     {
         private final SAMRecord _record;
         private final CigarOperator _op;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/button/ArchiveReadsetsButton.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/button/ArchiveReadsetsButton.java
@@ -3,8 +3,6 @@ package org.labkey.sequenceanalysis.button;
 import org.labkey.api.laboratory.security.LaboratoryAdminPermission;
 import org.labkey.api.ldk.table.SimpleButtonConfigFactory;
 import org.labkey.api.module.ModuleLoader;
-import org.labkey.api.security.permissions.AdminPermission;
-import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.view.template.ClientDependency;
 import org.labkey.sequenceanalysis.SequenceAnalysisModule;
 

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/button/ChangeReadsetStatusButton.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/button/ChangeReadsetStatusButton.java
@@ -5,7 +5,6 @@ import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.view.template.ClientDependency;
 import org.labkey.sequenceanalysis.SequenceAnalysisModule;
 
-import java.util.Arrays;
 import java.util.List;
 
 /**

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/button/ChangeReadsetStatusForAnalysesButton.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/button/ChangeReadsetStatusForAnalysesButton.java
@@ -5,7 +5,6 @@ import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.view.template.ClientDependency;
 import org.labkey.sequenceanalysis.SequenceAnalysisModule;
 
-import java.util.Arrays;
 import java.util.List;
 
 /**

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/button/ReprocessLibraryButton.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/button/ReprocessLibraryButton.java
@@ -5,7 +5,6 @@ import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.view.template.ClientDependency;
 import org.labkey.sequenceanalysis.SequenceAnalysisModule;
 
-import java.util.Arrays;
 import java.util.List;
 
 /**

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/model/UnderscoreBeanObjectFactory.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/model/UnderscoreBeanObjectFactory.java
@@ -1,7 +1,6 @@
 package org.labkey.sequenceanalysis.model;
 
 import org.labkey.api.data.BeanObjectFactory;
-import org.labkey.api.data.ObjectFactory;
 
 /**
  * Created by bimber on 2/20/2015.

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentAnalysisJob.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentAnalysisJob.java
@@ -23,7 +23,6 @@ import org.labkey.sequenceanalysis.util.SequenceUtil;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -65,7 +64,7 @@ public class AlignmentAnalysisJob extends SequenceJob
         List<AlignmentAnalysisJob> ret = new ArrayList<>();
         for (int i=0;i<analysisIds.length();i++)
         {
-            Integer analysisId = analysisIds.getInt(i);
+            int analysisId = analysisIds.getInt(i);
             AnalysisModelImpl model = AnalysisModelImpl.getFromDb(analysisId, u);
             if (model == null)
             {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentImportInitTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentImportInitTask.java
@@ -21,7 +21,6 @@ import org.labkey.sequenceanalysis.SequenceAnalysisSchema;
 import org.labkey.sequenceanalysis.SequenceReadsetImpl;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentImportJob.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentImportJob.java
@@ -17,7 +17,6 @@ import org.labkey.sequenceanalysis.util.SequenceUtil;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentImportTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentImportTask.java
@@ -27,7 +27,6 @@ import org.labkey.sequenceanalysis.model.AnalysisModelImpl;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -107,7 +106,7 @@ public class AlignmentImportTask extends WorkDirectoryTask<AlignmentImportTask.F
         Integer runId = SequenceTaskHelper.getExpRunIdForJob(getJob());
         ExpRun run = ExperimentService.get().getExpRun(runId);
         List<? extends ExpData> datas = run.getInputDatas(SequenceAlignmentTask.FINAL_BAM_ROLE, ExpProtocol.ApplicationType.ExperimentRunOutput);
-        if (datas.size() > 0)
+        if (!datas.isEmpty())
         {
             for (ExpData d : datas)
             {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentInitTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentInitTask.java
@@ -15,7 +15,6 @@ import org.labkey.api.sequenceanalysis.pipeline.SequencePipelineService;
 import org.labkey.api.util.FileType;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentNormalizationTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentNormalizationTask.java
@@ -31,7 +31,6 @@ import org.labkey.sequenceanalysis.util.SequenceUtil;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/CacheAlignerIndexesTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/CacheAlignerIndexesTask.java
@@ -21,7 +21,6 @@ import org.labkey.sequenceanalysis.run.util.FastaIndexer;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/CacheGenomePipelineJob.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/CacheGenomePipelineJob.java
@@ -30,7 +30,6 @@ import org.labkey.api.view.ViewContext;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ConvertToCramHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ConvertToCramHandler.java
@@ -91,7 +91,7 @@ public class ConvertToCramHandler extends AbstractParameterizedOutputHandler<Seq
         return new Processor();
     }
 
-    public class Processor implements SequenceOutputProcessor
+    public static class Processor implements SequenceOutputProcessor
     {
         @Override
         public void processFilesOnWebserver(PipelineJob job, SequenceAnalysisJobSupport support, List<SequenceOutputFile> inputFiles, JSONObject params, File outputDir, List<RecordedAction> actions, List<SequenceOutputFile> outputsToCreate) throws UnsupportedOperationException, PipelineJobException

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/CreateReferenceLibraryTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/CreateReferenceLibraryTask.java
@@ -62,7 +62,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -199,7 +198,7 @@ public class CreateReferenceLibraryTask extends PipelineJob.Task<CreateReference
                 libraryRow.put("description", getPipelineJob().getLibraryDescription());
 
                 BatchValidationException errors = new BatchValidationException();
-                List<Map<String, Object>> inserted = libraryTable.getUpdateService().insertRows(getJob().getUser(), getJob().getContainer(), List.of(libraryRow), errors, null, new HashMap<String, Object>());
+                List<Map<String, Object>> inserted = libraryTable.getUpdateService().insertRows(getJob().getUser(), getJob().getContainer(), List.of(libraryRow), errors, null, new HashMap<>());
                 if (errors.hasErrors())
                 {
                     throw errors;
@@ -419,7 +418,7 @@ public class CreateReferenceLibraryTask extends PipelineJob.Task<CreateReference
                 getJob().getLogger().info("updating database");
                 BatchValidationException errors = new BatchValidationException();
                 TableInfo libraryMembersTable = QueryService.get().getUserSchema(getJob().getUser(), getJob().getContainer(), SequenceAnalysisSchema.SCHEMA_NAME).getTable(SequenceAnalysisSchema.TABLE_REF_LIBRARY_MEMBERS);
-                libraryMembersTable.getUpdateService().insertRows(getJob().getUser(), getJob().getContainer(), toInsert, errors, null, new HashMap<String, Object>());
+                libraryMembersTable.getUpdateService().insertRows(getJob().getUser(), getJob().getContainer(), toInsert, errors, null, new HashMap<>());
                 if (errors.hasErrors())
                 {
                     throw errors;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/IlluminaFastqSplitter.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/IlluminaFastqSplitter.java
@@ -22,7 +22,6 @@ import htsjdk.samtools.fastq.FastqReader;
 import htsjdk.samtools.fastq.FastqRecord;
 import htsjdk.samtools.fastq.FastqWriter;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.util.FileType;
@@ -133,7 +132,7 @@ public class IlluminaFastqSplitter<SampleIdType>
                             FastqRecord fq = reader.next();
                             String header = fq.getReadHeader();
                             IlluminaReadHeader parsedHeader = new IlluminaReadHeader(header);
-                            String illuminaSampleId = null;
+                            String illuminaSampleId;
                             if (parsedHeader.getIndexSequenceString() != null)
                             {
                                 illuminaSampleId = parsedHeader.getIndexSequenceString();

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/IlluminaImportJob.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/IlluminaImportJob.java
@@ -19,7 +19,6 @@ import org.labkey.sequenceanalysis.SequenceAnalysisModule;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/IlluminaImportTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/IlluminaImportTask.java
@@ -49,7 +49,6 @@ import org.labkey.sequenceanalysis.SequenceAnalysisSchema;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -130,7 +129,7 @@ public class IlluminaImportTask extends WorkDirectoryTask<IlluminaImportTask.Fac
         String prefix = job.getParameters().get("fastqPrefix");
 
         List<File> inputFiles = getSupport().getInputFiles();
-        if (inputFiles.size() == 0)
+        if (inputFiles.isEmpty())
             throw new PipelineJobException("No input files");
 
         DbSchema schema = SequenceAnalysisSchema.getInstance().getSchema();
@@ -336,7 +335,7 @@ public class IlluminaImportTask extends WorkDirectoryTask<IlluminaImportTask.Fac
             Map<String, Integer> sampleMap = new HashMap<>();
             sampleMap.put("S0", 0); //placeholder for control and unmapped reads
 
-            Boolean inSamples = false;
+            boolean inSamples = false;
             int sampleIdx = 0;
             while ((nextLine = reader.readNext()) != null)
             {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/IlluminaReadsetCreationTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/IlluminaReadsetCreationTask.java
@@ -22,7 +22,6 @@ import org.labkey.api.util.FileType;
 import org.labkey.sequenceanalysis.SequenceAnalysisSchema;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ImportFastaSequencesTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ImportFastaSequencesTask.java
@@ -28,7 +28,6 @@ import org.labkey.sequenceanalysis.SequenceAnalysisManager;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ImportGenomeTrackPipelineJob.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ImportGenomeTrackPipelineJob.java
@@ -13,7 +13,6 @@ import org.labkey.api.pipeline.TaskPipeline;
 import org.labkey.api.query.DetailsURL;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.InsertPermission;
-import org.labkey.api.util.FileType;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewBackgroundInfo;
@@ -22,7 +21,6 @@ import org.labkey.sequenceanalysis.util.SequenceUtil;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 
 /**
  * User: bimber

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ImportGenomeTrackTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ImportGenomeTrackTask.java
@@ -229,7 +229,7 @@ public class ImportGenomeTrackTask extends PipelineJob.Task<ImportGenomeTrackTas
             knownChrs.put(m.getName(), m.getName());
         }
 
-        SAMSequenceDictionary dict = null;
+        SAMSequenceDictionary dict;
         if (!genome.getSequenceDictionary().exists())
         {
             SequencePipelineService.get().ensureSequenceDictionaryExists(genome.getWorkingFastaFile(), getJob().getLogger(), false);
@@ -410,12 +410,12 @@ public class ImportGenomeTrackTask extends PipelineJob.Task<ImportGenomeTrackTas
                     try
                     {
                         String strPart = m.getName().toLowerCase().replaceAll("^chr", "");
-                        Integer number = Integer.parseInt(strPart);
-                        ret.put(number.toString(), Pair.of(m.getName(), 0));
+                        String number = Integer.toString(Integer.parseInt(strPart));
+                        ret.put(number, Pair.of(m.getName(), 0));
 
-                        if (strPart.length() != number.toString().length())
+                        if (strPart.length() != number.length())
                         {
-                            for (String t : Arrays.asList(number.toString(), StringUtils.leftPad(number.toString(), 2, "0")))
+                            for (String t : Arrays.asList(number, StringUtils.leftPad(number, 2, "0")))
                             {
                                 String i = "chr" + t;
                                 if (!i.equalsIgnoreCase(m.getName()))
@@ -435,8 +435,8 @@ public class ImportGenomeTrackTask extends PipelineJob.Task<ImportGenomeTrackTas
                 {
                     try
                     {
-                        Integer number = Integer.parseInt(m.getName());
-                        for (String t : Arrays.asList(number.toString(), StringUtils.leftPad(number.toString(), 2, "0")))
+                        String number = Integer.toString(Integer.parseInt(m.getName()));
+                        for (String t : Arrays.asList(number, StringUtils.leftPad(number, 2, "0")))
                         {
                             String i = "chr" + t;
                             ret.put(i, Pair.of(m.getName(), 0));

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/JobContextImpl.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/JobContextImpl.java
@@ -130,6 +130,7 @@ public class JobContextImpl implements SequenceOutputHandler.MutableJobContext
         return _actions;
     }
 
+    @Override
     public Collection<String> getDockerVolumes()
     {
         return _job.getDockerVolumes();

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/OrphanFilePipelineJob.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/OrphanFilePipelineJob.java
@@ -289,7 +289,7 @@ public class OrphanFilePipelineJob extends PipelineJob
             TableInfo dataTable = ExperimentService.get().getTinfoData();
             TableSelector ts = new TableSelector(dataTable, PageFlowUtil.set("RowId", "DataFileUrl"), dataFilter, null);
             final Map<URI, Set<Integer>> dataMap = new HashMap<>();
-            ts.forEach(new Selector.ForEachBlock<ResultSet>()
+            ts.forEach(new Selector.ForEachBlock<>()
             {
                 @Override
                 public void exec(ResultSet rs) throws SQLException

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/PipelineStepCtxImpl.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/PipelineStepCtxImpl.java
@@ -10,7 +10,7 @@ import org.labkey.api.sequenceanalysis.pipeline.PipelineStepProvider;
 public class PipelineStepCtxImpl<StepType extends PipelineStep> implements PipelineStepCtx<StepType>
 {
     private final PipelineStepProvider<StepType> _provider;
-    private int _stepIdx = 0;
+    private int _stepIdx;
 
     public PipelineStepCtxImpl(PipelineStepProvider<StepType> provider, int stepIdx)
     {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/PrepareAlignerIndexesTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/PrepareAlignerIndexesTask.java
@@ -16,7 +16,6 @@ import org.labkey.api.util.FileType;
 import org.labkey.sequenceanalysis.run.util.FastaIndexer;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ProcessVariantsHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ProcessVariantsHandler.java
@@ -36,7 +36,6 @@ import org.labkey.api.sequenceanalysis.pipeline.ReferenceGenome;
 import org.labkey.api.sequenceanalysis.pipeline.SequenceAnalysisJobSupport;
 import org.labkey.api.sequenceanalysis.pipeline.SequenceOutputHandler;
 import org.labkey.api.sequenceanalysis.pipeline.SequencePipelineService;
-import org.labkey.api.sequenceanalysis.pipeline.TaskFileManager;
 import org.labkey.api.sequenceanalysis.pipeline.ToolParameterDescriptor;
 import org.labkey.api.sequenceanalysis.pipeline.VariantProcessingStep;
 import org.labkey.api.sequenceanalysis.run.SimpleScriptWrapper;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ReadsetCreationTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ReadsetCreationTask.java
@@ -254,7 +254,7 @@ public class ReadsetCreationTask extends PipelineJob.Task<ReadsetCreationTask.Fa
                     File f2 = rd.getFile2();
 
                     getJob().getLogger().debug("Total exp data files: " + datas.size());
-                    if (datas.size() > 0)
+                    if (!datas.isEmpty())
                     {
                         boolean found = false;
                         boolean found2 = false;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ReadsetImportJob.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ReadsetImportJob.java
@@ -30,7 +30,6 @@ import org.labkey.sequenceanalysis.util.NucleotideSequenceFileType;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ReblockGvcfHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ReblockGvcfHandler.java
@@ -90,7 +90,7 @@ public class ReblockGvcfHandler extends AbstractParameterizedOutputHandler<Seque
         return new Processor();
     }
 
-    public class Processor implements SequenceOutputProcessor
+    public static class Processor implements SequenceOutputProcessor
     {
         @Override
         public void processFilesOnWebserver(PipelineJob job, SequenceAnalysisJobSupport support, List<SequenceOutputFile> inputFiles, JSONObject params, File outputDir, List<RecordedAction> actions, List<SequenceOutputFile> outputsToCreate) throws UnsupportedOperationException, PipelineJobException

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceAlignmentJob.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceAlignmentJob.java
@@ -61,7 +61,7 @@ public class SequenceAlignmentJob extends SequenceJob
         List<SequenceAlignmentJob> ret = new ArrayList<>();
         for (int i=0;i<readsetIds.length();i++)
         {
-            Integer readsetId = readsetIds.getInt(i);
+            int readsetId = readsetIds.getInt(i);
             SequenceReadsetImpl readset = SequenceAnalysisServiceImpl.get().getReadset(readsetId, u);
             if (readset == null)
             {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceConcatTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceConcatTask.java
@@ -20,19 +20,15 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.User;
 import org.labkey.api.sequenceanalysis.RefNtSequenceModel;
 import org.labkey.api.util.FileType;
-import org.labkey.api.util.Pair;
 import org.labkey.api.writer.PrintWriters;
 import org.labkey.sequenceanalysis.SequenceAnalysisSchema;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Created by bimber on 11/3/2016.
@@ -153,7 +149,7 @@ public class SequenceConcatTask extends PipelineJob.Task<SequenceConcatTask.Fact
         {
             d.append(description);
         }
-        if (d.length() > 0)
+        if (!d.isEmpty())
         {
             d.append(", ");
         }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceJobSupportImpl.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceJobSupportImpl.java
@@ -3,7 +3,6 @@ package org.labkey.sequenceanalysis.pipeline;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import htsjdk.samtools.util.IOUtil;
-import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.exp.api.ExpData;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceNormalizationTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceNormalizationTask.java
@@ -156,7 +156,7 @@ public class SequenceNormalizationTask extends WorkDirectoryTask<SequenceNormali
     {
         SequencePipelineSettings settings = new SequencePipelineSettings(job.getParameters());
 
-        return settings.isRunFastqc() || getFilesToNormalize(job, ((FileAnalysisJobSupport) job).getInputFiles(), true).size() > 0;
+        return settings.isRunFastqc() || !getFilesToNormalize(job, ((FileAnalysisJobSupport) job).getInputFiles(), true).isEmpty();
     }
 
     private ReadsetImportJob getPipelineJob()
@@ -517,7 +517,7 @@ public class SequenceNormalizationTask extends WorkDirectoryTask<SequenceNormali
                         }
                     }
 
-                    if (outputs.size() > 0)
+                    if (!outputs.isEmpty())
                     {
                         for (FileGroup.FilePair fp : fg.filePairs)
                         {
@@ -772,7 +772,7 @@ public class SequenceNormalizationTask extends WorkDirectoryTask<SequenceNormali
             barcoder.setCreateDetailedLog(true);
         }
 
-        if (getBarcodeGroupsToScan(getHelper().getSettings()).size() > 0)
+        if (!getBarcodeGroupsToScan(getHelper().getSettings()).isEmpty())
             barcoder.setScanAll(true);
 
         return barcoder;
@@ -887,7 +887,7 @@ public class SequenceNormalizationTask extends WorkDirectoryTask<SequenceNormali
         workingDir.mkdirs();
 
         FileType gz = new FileType("gz");
-        File output = null;
+        File output;
         //NOTE: if the file is ASCII33 FASTQ, it should not reach this stage, unless we're doing barcoding or merging
         if (type.equals(SequenceUtil.FILETYPE.fastq))
         {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceOutputHandlerJob.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceOutputHandlerJob.java
@@ -111,7 +111,9 @@ public class SequenceOutputHandlerJob extends SequenceJob implements HasJobParam
             try (InputStream is = IOUtil.maybeBufferInputStream(IOUtil.openFileForReading(xml)))
             {
                 ObjectMapper objectMapper = createObjectMapper();
-                List<SequenceOutputFile> ret = objectMapper.readValue(is, new TypeReference<List<SequenceOutputFile>>(){});
+                List<SequenceOutputFile> ret = objectMapper.readValue(is, new TypeReference<>()
+                {
+                });
                 getLogger().debug("read SequenceOutputFiles from file, total: " + ret.size());
 
                 for (SequenceOutputFile so : ret)

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceOutputHandlerRemoteTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceOutputHandlerRemoteTask.java
@@ -16,7 +16,6 @@ import org.labkey.api.sequenceanalysis.pipeline.SequencePipelineService;
 import org.labkey.api.util.FileType;
 import org.labkey.sequenceanalysis.SequenceAnalysisServiceImpl;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceTaskHelper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceTaskHelper.java
@@ -346,6 +346,7 @@ public class SequenceTaskHelper implements PipelineContext
         }
     }
 
+    @Override
     public Collection<String> getDockerVolumes()
     {
         return _job.getDockerVolumes();

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/TaskFileManagerImpl.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/TaskFileManagerImpl.java
@@ -1060,7 +1060,7 @@ public class TaskFileManagerImpl implements TaskFileManager, Serializable
         //NOTE: because we can initate runs on readsets from different containers, we cannot rely on dataDirectory() to be consistent
         //b/c inputs are always copied to the root of the analysis folder, we will use relative paths
         FileType gz = new FileType(".gz");
-        File unzipped = null;
+        File unzipped;
         if (gz.isType(i))
         {
             RecordedAction action = new RecordedAction(SequenceAlignmentTask.DECOMPRESS_ACTIONNAME);

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/VariantProcessingJob.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/VariantProcessingJob.java
@@ -26,7 +26,6 @@ import org.labkey.api.pipeline.PipelineJobService;
 import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.pipeline.TaskId;
 import org.labkey.api.pipeline.TaskPipeline;
-import org.labkey.api.pipeline.WorkDirectory;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.reader.Readers;
 import org.labkey.api.security.User;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/VariantProcessingRemoteMergeTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/VariantProcessingRemoteMergeTask.java
@@ -17,7 +17,6 @@ import org.labkey.api.sequenceanalysis.pipeline.ReferenceGenome;
 import org.labkey.api.sequenceanalysis.pipeline.SequenceOutputHandler;
 import org.labkey.api.sequenceanalysis.pipeline.VariantProcessingStep;
 import org.labkey.api.util.FileType;
-import org.labkey.sequenceanalysis.run.variant.OutputVariantsStartingInIntervalsStep;
 
 import java.io.File;
 import java.io.IOException;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/query/DownloadSequenceDisplayColumnFactory.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/query/DownloadSequenceDisplayColumnFactory.java
@@ -8,7 +8,6 @@ import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.util.LinkBuilder;
-import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.template.ClientDependency;
 import org.labkey.api.writer.HtmlWriter;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/query/GenbankDisplayColumnFactory.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/query/GenbankDisplayColumnFactory.java
@@ -6,12 +6,7 @@ import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.util.LinkBuilder;
-import org.labkey.api.util.PageFlowUtil;
-import org.labkey.api.util.URLHelper;
 import org.labkey.api.writer.HtmlWriter;
-
-import java.io.IOException;
-import java.io.Writer;
 
 /**
  * Created by bimber on 2/8/2017.

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/query/SequenceAnalysisUserSchema.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/query/SequenceAnalysisUserSchema.java
@@ -192,7 +192,7 @@ public class SequenceAnalysisUserSchema extends SimpleUserSchema
             }
         }
 
-        ret.getButtonBarConfig().setScriptIncludes(scriptIncludes.toArray(new String[scriptIncludes.size()]));
+        ret.getButtonBarConfig().setScriptIncludes(scriptIncludes.toArray(new String[0]));
 
         if (ret.getColumn("analysisSets") == null)
         {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/query/SequenceTriggerHelper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/query/SequenceTriggerHelper.java
@@ -43,8 +43,8 @@ import java.util.Map;
  */
 public class SequenceTriggerHelper
 {
-    private Container _container = null;
-    private User _user = null;
+    private Container _container;
+    private User _user;
     private static final Logger _log = LogManager.getLogger(SequenceTriggerHelper.class);
     private TableInfo _refNts = null;
 

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/MultiQcRunner.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/MultiQcRunner.java
@@ -2,7 +2,6 @@ package org.labkey.sequenceanalysis.run;
 
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.pipeline.PipelineJobService;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/alignment/BWAMem2Wrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/alignment/BWAMem2Wrapper.java
@@ -1,29 +1,19 @@
 package org.labkey.sequenceanalysis.run.alignment;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.labkey.api.pipeline.PipelineJob;
-import org.labkey.api.pipeline.PipelineJobException;
-import org.labkey.api.sequenceanalysis.model.Readset;
 import org.labkey.api.sequenceanalysis.pipeline.AbstractAlignmentStepProvider;
-import org.labkey.api.sequenceanalysis.pipeline.AlignmentOutputImpl;
 import org.labkey.api.sequenceanalysis.pipeline.AlignmentStep;
 import org.labkey.api.sequenceanalysis.pipeline.AlignmentStepProvider;
 import org.labkey.api.sequenceanalysis.pipeline.CommandLineParam;
 import org.labkey.api.sequenceanalysis.pipeline.PipelineContext;
-import org.labkey.api.sequenceanalysis.pipeline.ReferenceGenome;
-import org.labkey.api.sequenceanalysis.pipeline.SamtoolsRunner;
 import org.labkey.api.sequenceanalysis.pipeline.SequencePipelineService;
 import org.labkey.api.sequenceanalysis.pipeline.ToolParameterDescriptor;
-import org.labkey.api.util.FileUtil;
-import org.labkey.sequenceanalysis.util.SequenceUtil;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 
 /**
  * User: bimber

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/alignment/BWASWWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/alignment/BWASWWrapper.java
@@ -2,7 +2,6 @@ package org.labkey.sequenceanalysis.run.alignment;
 
 import htsjdk.samtools.ValidationStringency;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.pipeline.PipelineJobException;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/alignment/FastaToTwoBitRunner.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/alignment/FastaToTwoBitRunner.java
@@ -1,7 +1,6 @@
 package org.labkey.sequenceanalysis.run.alignment;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.pipeline.AlignerIndexUtil;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/alignment/FastqCollapser.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/alignment/FastqCollapser.java
@@ -1,7 +1,6 @@
 package org.labkey.sequenceanalysis.run.alignment;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.pipeline.SequencePipelineService;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/alignment/ParagraphStep.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/alignment/ParagraphStep.java
@@ -196,7 +196,7 @@ public class ParagraphStep extends AbstractParameterizedOutputHandler<SequenceOu
                 //    id  path    depth   read length
                 //    IB18  ../IB18.cram 29.77   150
                 File coverageFile = new File(ctx.getWorkingDirectory(), "coverage.txt");
-                String rgId = null;
+                String rgId;
                 try (PrintWriter writer = PrintWriters.getPrintWriter(coverageFile); SamReader reader = SamReaderFactory.makeDefault().open(so.getFile()))
                 {
                     SAMFileHeader header = reader.getFileHeader();

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/alignment/StarWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/alignment/StarWrapper.java
@@ -405,15 +405,15 @@ public class StarWrapper extends AbstractCommandWrapper
                         getPipelineCtx().getLogger().info("reference has " + refNumber + " contigs, adjusting parameters");
                         getPipelineCtx().getLogger().info("genome length: " + genomeLength);
 
-                        Double scale = Math.min(18.0, (Math.log((genomeLength / refNumber)) / Math.log(2)));
+                        double scale = Math.min(18.0, (Math.log((genomeLength / refNumber)) / Math.log(2)));
                         args.add("--genomeChrBinNbits");
-                        args.add(String.valueOf(scale.intValue()));
+                        args.add(String.valueOf((int) scale));
                     }
 
                     //and small genomes may require this
-                    Double genomeSAindexNbases = Math.min(14.0, ((Math.log(genomeLength) / Math.log(2)) / 2) - 1);
+                    double genomeSAindexNbases = Math.min(14.0, ((Math.log(genomeLength) / Math.log(2)) / 2) - 1);
                     args.add("--genomeSAindexNbases");
-                    args.add(String.valueOf(genomeSAindexNbases.intValue()));
+                    args.add(String.valueOf((int) genomeSAindexNbases));
                 }
                 catch (IOException e)
                 {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/alignment/VulcanWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/alignment/VulcanWrapper.java
@@ -20,7 +20,6 @@ import org.labkey.api.sequenceanalysis.run.AbstractCommandWrapper;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 //// vulcan -i $FASTQ -clr -t 12 -r $REF -w $WORK_DIR -o $OUT_DIR/${OUT}.bam

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/AASnpByCodonAggregator.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/AASnpByCodonAggregator.java
@@ -164,7 +164,7 @@ public class AASnpByCodonAggregator extends NtSnpByPosAggregator
 
             if (depth != null && !info.getReadResidue().equals(":"))
             {
-                Double adj_depth = info.calculateNtDepth(true);
+                double adj_depth = info.calculateNtDepth(true);
                 double pct = depth == 0 ? 0 : ((double) readCount / adj_depth ) * 100.0;
                 row.put("adj_depth", adj_depth);
                 row.put("pct", pct);
@@ -322,7 +322,7 @@ public class AASnpByCodonAggregator extends NtSnpByPosAggregator
             String ntPosString = snp.getNtPositionString();
             if (!_readnamesByPos.containsKey(ntPosString))
             {
-                _readnamesByPos.put(ntPosString, new HashSet<String>());
+                _readnamesByPos.put(ntPosString, new HashSet<>());
             }
 
             if (_readnamesByPos.get(ntPosString).contains(snp.getNtSnp().getReadname()))

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/AASnpByReadAggregator.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/AASnpByReadAggregator.java
@@ -65,7 +65,7 @@ public class AASnpByReadAggregator extends AASnpByCodonAggregator
             highQualitySnpsByPos.put(pos, highQualitySnps);
         }
 
-        if (highQualitySnpsByPos.size() > 0)
+        if (!highQualitySnpsByPos.isEmpty())
         {
             for (AASnp snp : translateSnpsForRead(record, highQualitySnpsByPos))
             {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/AbstractAlignmentAggregator.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/AbstractAlignmentAggregator.java
@@ -19,7 +19,6 @@ import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.reference.ReferenceSequence;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.ReferenceLibraryHelper;
 import org.labkey.sequenceanalysis.run.util.AASnp;
@@ -28,7 +27,6 @@ import org.labkey.sequenceanalysis.util.ReferenceLibraryHelperImpl;
 import org.labkey.sequenceanalysis.util.TranslatingReferenceSequence;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -320,7 +318,7 @@ abstract public class AbstractAlignmentAggregator implements AlignmentAggregator
         _minDipQual = minDipQual;
     }
 
-    protected class CacheKeyInfo
+    protected static class CacheKeyInfo
     {
         private final String _refName;
         private final Integer _refPosition;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/AvgBaseQualityAggregator.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/AvgBaseQualityAggregator.java
@@ -48,7 +48,7 @@ public class AvgBaseQualityAggregator
     private final File _bai;
     private final File _ref;
     private Map<Integer, Map<String, Double>> _quals = null;
-    private List<SamRecordFilter> _filters = null;
+    private List<SamRecordFilter> _filters;
 
     public AvgBaseQualityAggregator(Logger log, File bam, File refFasta) throws FileNotFoundException
     {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/BamIterator.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/BamIterator.java
@@ -164,7 +164,6 @@ public class BamIterator
 
     /**
      * Iterates all reads in the alignment
-     * @return
      */
     public void iterateReads() throws IOException, PipelineJobException
     {
@@ -206,7 +205,7 @@ public class BamIterator
                 }
             }
 
-            if (snps.size() > 0)
+            if (!snps.isEmpty())
                 snpPositions.put(pi.getLastRefPosition(), snps);
         }
 
@@ -218,7 +217,7 @@ public class BamIterator
             {
                 Integer pos1 = snp1.getLastRefPosition();
                 Integer idx1 = snp1.getInsertIndex();
-                Integer compare1 = pos1.compareTo(snp2.getLastRefPosition());
+                int compare1 = pos1.compareTo(snp2.getLastRefPosition());
 
                 return compare1 != 0 ? compare1 : idx1.compareTo(snp2.getInsertIndex());
             });

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/ExportOverlappingReadsAnalysis.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/ExportOverlappingReadsAnalysis.java
@@ -110,8 +110,8 @@ public class ExportOverlappingReadsAnalysis extends AbstractPipelineStep impleme
                 }
 
                 String refName = m.group(1);
-                Integer start = Integer.parseInt(m.group(2));
-                Integer stop = Integer.parseInt(m.group(3));
+                int start = Integer.parseInt(m.group(2));
+                int stop = Integer.parseInt(m.group(3));
 
                 getPipelineCtx().getLogger().info("calculating bases over " + refName + ": " + start + "-" + stop);
                 int added = calculateForInterval(inputBam, refName, start, stop, distinctReadNames);

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/MergeLoFreqVcfHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/MergeLoFreqVcfHandler.java
@@ -132,7 +132,7 @@ public class MergeLoFreqVcfHandler extends AbstractParameterizedOutputHandler<Se
 
         private static final double NO_DATA_VAL = -1.0;
 
-        private class SiteAndAlleles
+        private static class SiteAndAlleles
         {
             private final String _contig;
             private final int _start;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/NextCladeHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/NextCladeHandler.java
@@ -299,10 +299,10 @@ public class NextCladeHandler extends AbstractParameterizedOutputHandler<Sequenc
                 throw new PipelineJobException("Expected variant for AA position: " + aaName + " " + pos);
             }
 
-            Double depth;
-            Double alleleDepth;
-            Double af;
-            Double dp;
+            double depth;
+            double alleleDepth;
+            double af;
+            double dp;
 
             List<String> ntPositions = new ArrayList<>();
             if (vcList.size() == 1)

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/NtCoverageAggregator.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/NtCoverageAggregator.java
@@ -18,7 +18,6 @@ package org.labkey.sequenceanalysis.run.analysis;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.reference.ReferenceSequence;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.SimpleFilter;
@@ -388,7 +387,7 @@ public class NtCoverageAggregator extends AbstractAlignmentAggregator
                         for (char base : _baseMap.keySet())
                         {
                             String fieldSuffix = _baseMap.get(base);
-                            Integer baseTotal = getValueForPositionAndBase(refName, position, index, base, _totalCoverageByBase);
+                            int baseTotal = getValueForPositionAndBase(refName, position, index, base, _totalCoverageByBase);
 
                             row.put("total_" + fieldSuffix, baseTotal);
 
@@ -397,7 +396,7 @@ public class NtCoverageAggregator extends AbstractAlignmentAggregator
                                 n_total += baseTotal;
 
                             double totalQual = getValueForPositionAndBase(refName, position, index, base, _totalQualByBase);
-                            double avgQual = baseTotal == 0 ? 0 : totalQual / baseTotal.doubleValue();
+                            double avgQual = baseTotal == 0 ? 0 : totalQual / (double) baseTotal;
                             row.put("avgqual_" + fieldSuffix, avgQual);
 
                             if (index == 0 && base == wtBase)

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/NtSnpByPosAggregator.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/NtSnpByPosAggregator.java
@@ -18,7 +18,6 @@ package org.labkey.sequenceanalysis.run.analysis;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.reference.ReferenceSequence;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.SimpleFilter;
@@ -30,7 +29,6 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.User;
 import org.labkey.api.sequenceanalysis.model.AnalysisModel;
 import org.labkey.sequenceanalysis.SequenceAnalysisSchema;
-import org.labkey.sequenceanalysis.api.picard.CigarPositionIterable;
 import org.labkey.sequenceanalysis.run.util.NTSnp;
 
 import java.io.File;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/PARalyzerAnalysis.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/PARalyzerAnalysis.java
@@ -19,7 +19,6 @@ import org.labkey.sequenceanalysis.run.util.PARalyzerRunner;
 import java.io.File;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/PindelAnalysis.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/PindelAnalysis.java
@@ -146,9 +146,9 @@ public class PindelAnalysis extends AbstractPipelineStep implements AnalysisStep
             {
                 if (m.PAIR_ORIENTATION == SamPairUtil.PairOrientation.FR)
                 {
-                    Double insertSize = Math.ceil(m.MEAN_INSERT_SIZE);
+                    double insertSize = Math.ceil(m.MEAN_INSERT_SIZE);
 
-                    return String.valueOf(Math.max(minInsertSize, insertSize.intValue()));
+                    return String.valueOf(Math.max(minInsertSize, (int) insertSize));
                 }
             }
         }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/SequenceBasedTypingAlignmentAggregator.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/SequenceBasedTypingAlignmentAggregator.java
@@ -187,7 +187,7 @@ public class SequenceBasedTypingAlignmentAggregator extends AbstractAlignmentAgg
                 return;
             }
 
-            Integer numSnps = getNumMismatches(record, snps);
+            int numSnps = getNumMismatches(record, snps);
             String key = getKey(record);
             if (numSnps <= _maxSNPs)
             {
@@ -352,7 +352,7 @@ public class SequenceBasedTypingAlignmentAggregator extends AbstractAlignmentAgg
             List<String> refNames2 = null;
 
             //if this read has an aligned mate, we find the intersect between its alignments
-            Boolean hasMate = false;
+            boolean hasMate = false;
             if (_alignmentsByReadM2.containsKey(readName))
             {
                 refNames2 = new ArrayList<>(_alignmentsByReadM2.get(readName));
@@ -383,11 +383,11 @@ public class SequenceBasedTypingAlignmentAggregator extends AbstractAlignmentAgg
 
                 for (String refName : names)
                 {
-                    writer.writeNext(new String[]{"Forward", readName, String.valueOf(_alignmentsByReadM1.get(readName).size()), String.valueOf(refNames.size()), refName, String.valueOf(refNames.contains(refName)), hasMate.toString()});
+                    writer.writeNext(new String[]{"Forward", readName, String.valueOf(_alignmentsByReadM1.get(readName).size()), String.valueOf(refNames.size()), refName, String.valueOf(refNames.contains(refName)), Boolean.toString(hasMate)});
                 }
             }
 
-            if (refNames.size() > 0)
+            if (!refNames.isEmpty())
             {
                 if (!_onlyImportValidPairs || hasMate)
                 {
@@ -434,7 +434,7 @@ public class SequenceBasedTypingAlignmentAggregator extends AbstractAlignmentAgg
             List<String> refNames = new ArrayList(_alignmentsByReadM2.get(mateName));
             if (!_onlyImportValidPairs)
             {
-                if (refNames.size() > 0)
+                if (!refNames.isEmpty())
                 {
                     appendReadToTotals(mateName, refNames, totals, false, true);
                     _singletonCalls++;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/SequenceBasedTypingAnalysis.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/SequenceBasedTypingAnalysis.java
@@ -35,7 +35,6 @@ import org.labkey.api.sequenceanalysis.pipeline.PipelineStepProvider;
 import org.labkey.api.sequenceanalysis.pipeline.ReferenceGenome;
 import org.labkey.api.sequenceanalysis.pipeline.SequenceAnalysisJobSupport;
 import org.labkey.api.sequenceanalysis.pipeline.ToolParameterDescriptor;
-import org.labkey.api.util.Compress;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
@@ -184,7 +183,7 @@ public class SequenceBasedTypingAnalysis extends AbstractPipelineStep implements
                 log.info("writing lineage map file");
                 SQLFragment sql = new SQLFragment("SELECT r.name, r.lineage FROM " + SequenceAnalysisSchema.SCHEMA_NAME + "." + SequenceAnalysisSchema.TABLE_REF_NT_SEQUENCES + " r WHERE r.rowid IN (SELECT ref_nt_id FROM " + SequenceAnalysisSchema.SCHEMA_NAME + "." + SequenceAnalysisSchema.TABLE_REF_LIBRARY_MEMBERS + " WHERE library_id = ?)", genome.getGenomeId());
                 SqlSelector ss = new SqlSelector(DbScope.getLabKeyScope(), sql);
-                ss.forEach(new Selector.ForEachBlock<ResultSet>()
+                ss.forEach(new Selector.ForEachBlock<>()
                 {
                     @Override
                     public void exec(ResultSet rs) throws SQLException

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/SnpCountAnalysis.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/SnpCountAnalysis.java
@@ -32,7 +32,6 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -123,8 +122,8 @@ public class SnpCountAnalysis extends AbstractPipelineStep implements AnalysisSt
                 }
 
                 String refName = m.group(1);
-                Integer start = Integer.parseInt(m.group(2));
-                Integer stop = Integer.parseInt(m.group(3));
+                int start = Integer.parseInt(m.group(2));
+                int stop = Integer.parseInt(m.group(3));
 
                 getPipelineCtx().getLogger().info("calculating bases over " + refName + ": " + start + "-" + stop);
                 calculateForInterval(writer, inputBam, indexFile, indexedFastaSequenceFile, inputBam.getName(), rs.getName(), refName, start, stop);

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/UnmappedReadExportAnalysis.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/UnmappedReadExportAnalysis.java
@@ -35,7 +35,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/assembly/TrinityRunner.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/assembly/TrinityRunner.java
@@ -20,7 +20,6 @@ import org.labkey.sequenceanalysis.run.analysis.AssemblyOutputImpl;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/bampostprocessing/ClipOverlappingAlignmentsWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/bampostprocessing/ClipOverlappingAlignmentsWrapper.java
@@ -18,7 +18,6 @@ import org.labkey.api.util.FileUtil;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/bampostprocessing/DiscardUnmappedReadsStep.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/bampostprocessing/DiscardUnmappedReadsStep.java
@@ -1,7 +1,5 @@
 package org.labkey.sequenceanalysis.run.bampostprocessing;
 
-import htsjdk.samtools.SAMFileHeader;
-import htsjdk.samtools.ValidationStringency;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.model.Readset;
 import org.labkey.api.sequenceanalysis.pipeline.AbstractPipelineStepProvider;
@@ -11,14 +9,10 @@ import org.labkey.api.sequenceanalysis.pipeline.PipelineContext;
 import org.labkey.api.sequenceanalysis.pipeline.PipelineStepProvider;
 import org.labkey.api.sequenceanalysis.pipeline.ReferenceGenome;
 import org.labkey.api.sequenceanalysis.pipeline.SamtoolsRunner;
-import org.labkey.api.sequenceanalysis.pipeline.SequencePipelineService;
-import org.labkey.api.sequenceanalysis.pipeline.SortSamWrapper;
 import org.labkey.api.sequenceanalysis.run.AbstractCommandPipelineStep;
 import org.labkey.api.util.FileUtil;
-import org.labkey.sequenceanalysis.util.SequenceUtil;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/bampostprocessing/IndelRealignerStep.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/bampostprocessing/IndelRealignerStep.java
@@ -1,6 +1,5 @@
 package org.labkey.sequenceanalysis.run.bampostprocessing;
 
-import org.json.JSONObject;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.model.Readset;
 import org.labkey.api.sequenceanalysis.pipeline.AbstractPipelineStepProvider;
@@ -9,13 +8,11 @@ import org.labkey.api.sequenceanalysis.pipeline.BamProcessingStep;
 import org.labkey.api.sequenceanalysis.pipeline.PipelineContext;
 import org.labkey.api.sequenceanalysis.pipeline.PipelineStepProvider;
 import org.labkey.api.sequenceanalysis.pipeline.ReferenceGenome;
-import org.labkey.api.sequenceanalysis.pipeline.ToolParameterDescriptor;
 import org.labkey.api.sequenceanalysis.run.AbstractCommandPipelineStep;
 import org.labkey.api.util.FileUtil;
 import org.labkey.sequenceanalysis.run.util.IndelRealignerWrapper;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.Collections;
 
 /**

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/preprocessing/BlastFilterPipelineStep.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/preprocessing/BlastFilterPipelineStep.java
@@ -174,7 +174,7 @@ public class BlastFilterPipelineStep extends AbstractPipelineStep implements Pre
         try (CSVReader reader = new CSVReader(Readers.getReader(blastOutput), '\t'))
         {
             String[] line;
-            while ((line = reader.readNext()) != null)
+            while (reader.readNext() != null)
             {
 
             }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/preprocessing/CutadaptWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/preprocessing/CutadaptWrapper.java
@@ -11,7 +11,6 @@ import org.labkey.api.sequenceanalysis.pipeline.AbstractPipelineStepProvider;
 import org.labkey.api.sequenceanalysis.pipeline.PipelineContext;
 import org.labkey.api.sequenceanalysis.pipeline.PipelineStepProvider;
 import org.labkey.api.sequenceanalysis.pipeline.PreprocessingStep;
-import org.labkey.api.sequenceanalysis.pipeline.SequencePipelineService;
 import org.labkey.api.sequenceanalysis.run.AbstractCommandPipelineStep;
 import org.labkey.api.sequenceanalysis.run.AbstractCommandWrapper;
 import org.labkey.api.sequenceanalysis.pipeline.CommandLineParam;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/preprocessing/DownsampleFastqWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/preprocessing/DownsampleFastqWrapper.java
@@ -20,7 +20,6 @@ import org.labkey.sequenceanalysis.run.util.SamToFastqWrapper;
 import org.labkey.sequenceanalysis.util.FastqUtils;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.List;
 
 /**

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/preprocessing/SeqtkRunner.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/preprocessing/SeqtkRunner.java
@@ -1,7 +1,6 @@
 package org.labkey.sequenceanalysis.run.preprocessing;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.pipeline.SequencePipelineService;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/preprocessing/Sff2FastqRunner.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/preprocessing/Sff2FastqRunner.java
@@ -1,7 +1,6 @@
 package org.labkey.sequenceanalysis.run.preprocessing;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.pipeline.SequencePipelineService;
@@ -10,8 +9,6 @@ import org.labkey.api.sequenceanalysis.run.AbstractCommandWrapper;
 import java.io.File;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * User: bimber

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/preprocessing/TrimmomaticWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/preprocessing/TrimmomaticWrapper.java
@@ -152,7 +152,7 @@ public class TrimmomaticWrapper extends AbstractCommandWrapper
         @Override
         public Double getThreshold(PipelineContext ctx, int stepIdx)
         {
-            Double ret = 0.0;
+            double ret = 0.0;
             for (Pair<AbstractTrimmomaticProvider, Integer> provider : _providers)
             {
                 Double val = provider.first.getParameterByName(MIN_PCT_RETAINED).extractValue(ctx.getJob(), this, stepIdx, Double.class);
@@ -795,8 +795,8 @@ public class TrimmomaticWrapper extends AbstractCommandWrapper
                         }
                     }
 
-                    Double avgBasesTrimmed = totalReadsTrimmed == 0 ? 0 : (double)totalBasesTrimmed / (double)totalReadsTrimmed;
-                    Double avgReadLength = totalReadsTrimmed == 0 ? 0 : (double)totalLength / (double)totalReadsRetained;
+                    double avgBasesTrimmed = totalReadsTrimmed == 0 ? 0 : (double)totalBasesTrimmed / (double)totalReadsTrimmed;
+                    double avgReadLength = totalReadsTrimmed == 0 ? 0 : (double)totalLength / (double)totalReadsRetained;
                     Double pctRetained =(double)totalReadsRetained / totalInspected;
                     results.add(pctRetained);
                     StringBuilder summary = new StringBuilder();

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/AASnp.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/AASnp.java
@@ -97,7 +97,7 @@ public class AASnp
                     _log.error("unable to translate string: " + _codon, e);
                 }
 
-                if (_residueString == null || "".equals(_residueString))
+                if (_residueString == null || _residueString.isEmpty())
                 {
                     _residueString = "*";
                 }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/AbstractGenomicsDBImportHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/AbstractGenomicsDBImportHandler.java
@@ -629,7 +629,7 @@ abstract public class AbstractGenomicsDBImportHandler extends AbstractParameteri
                     }
 
                     Integer maxRam = SequencePipelineService.get().getMaxRam();
-                    Integer nativeMemoryBuffer = ctx.getParams().optInt("nativeMemoryBuffer", 0);
+                    int nativeMemoryBuffer = ctx.getParams().optInt("nativeMemoryBuffer", 0);
                     if (maxRam != null && nativeMemoryBuffer > 0)
                     {
                         ctx.getLogger().info("Adjusting RAM based on memory buffer (" + nativeMemoryBuffer + "), from: " + maxRam);

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/BlastNWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/BlastNWrapper.java
@@ -1,7 +1,6 @@
 package org.labkey.sequenceanalysis.run.util;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.pipeline.PipelineJobService;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/CollectWgsMetricsWithNonZeroCoverageWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/CollectWgsMetricsWithNonZeroCoverageWrapper.java
@@ -1,7 +1,6 @@
 package org.labkey.sequenceanalysis.run.util;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 /**
  * Created by bimber on 6/29/2017.

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/CombineGVCFsHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/CombineGVCFsHandler.java
@@ -170,7 +170,7 @@ public class CombineGVCFsHandler extends AbstractParameterizedOutputHandler<Sequ
                     }
                 }
 
-                wrapper.execute(genome.getWorkingFastaFile(), outputFile, options, vcfsToProcess.toArray(new File[vcfsToProcess.size()]));
+                wrapper.execute(genome.getWorkingFastaFile(), outputFile, options, vcfsToProcess.toArray(new File[0]));
             }
 
             if (!outputFile.exists())

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/CombineGVCFsWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/CombineGVCFsWrapper.java
@@ -1,7 +1,6 @@
 package org.labkey.sequenceanalysis.run.util;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.SequenceAnalysisService;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/DepthOfCoverageWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/DepthOfCoverageWrapper.java
@@ -1,7 +1,6 @@
 package org.labkey.sequenceanalysis.run.util;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.run.AbstractGatk4Wrapper;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/DownsampleSamWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/DownsampleSamWrapper.java
@@ -1,7 +1,6 @@
 package org.labkey.sequenceanalysis.run.util;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.run.PicardWrapper;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/EstimateLibraryComplexityWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/EstimateLibraryComplexityWrapper.java
@@ -2,7 +2,6 @@ package org.labkey.sequenceanalysis.run.util;
 
 import htsjdk.samtools.SAMFileHeader;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.pipeline.SamSorter;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/FastaIndexer.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/FastaIndexer.java
@@ -1,7 +1,6 @@
 package org.labkey.sequenceanalysis.run.util;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.pipeline.SamtoolsRunner;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/FastqToSamWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/FastqToSamWrapper.java
@@ -4,7 +4,6 @@ import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMReadGroupRecord;
 import htsjdk.samtools.util.FastqQualityFormat;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.run.PicardWrapper;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/FastqcRunner.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/FastqcRunner.java
@@ -46,13 +46,11 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 
 /**

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/FixMateInformationWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/FixMateInformationWrapper.java
@@ -2,7 +2,6 @@ package org.labkey.sequenceanalysis.run.util;
 
 import htsjdk.samtools.SAMFileHeader;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.run.PicardWrapper;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/FlagStatRunner.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/FlagStatRunner.java
@@ -2,7 +2,6 @@ package org.labkey.sequenceanalysis.run.util;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.pipeline.SamtoolsRunner;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/FlashWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/FlashWrapper.java
@@ -1,7 +1,6 @@
 package org.labkey.sequenceanalysis.run.util;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.pipeline.SequencePipelineService;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/GFFReadWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/GFFReadWrapper.java
@@ -2,10 +2,8 @@ package org.labkey.sequenceanalysis.run.util;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
-import org.labkey.api.sequenceanalysis.SequenceAnalysisService;
 import org.labkey.api.sequenceanalysis.pipeline.SequencePipelineService;
 import org.labkey.api.sequenceanalysis.run.AbstractCommandWrapper;
 import org.labkey.api.util.FileUtil;
@@ -66,7 +64,7 @@ public class GFFReadWrapper extends AbstractCommandWrapper
             }
 
             Double lineCountStart = ((Long)SequencePipelineService.get().getLineCount(gxf)).doubleValue();
-            Double lineCountEnd = ((Long)SequencePipelineService.get().getLineCount(outputFile)).doubleValue();
+            double lineCountEnd = ((Long)SequencePipelineService.get().getLineCount(outputFile)).doubleValue();
             if (lineCountEnd == 0)
             {
                 throw new PipelineJobException("No lines remain after sorting");

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/IdxStatsRunner.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/IdxStatsRunner.java
@@ -2,7 +2,6 @@ package org.labkey.sequenceanalysis.run.util;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.pipeline.SamtoolsRunner;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/ImmunoGenotypingWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/ImmunoGenotypingWrapper.java
@@ -1,7 +1,6 @@
 package org.labkey.sequenceanalysis.run.util;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.run.AbstractDiscvrSeqWrapper;
 

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/LiftoverVcfWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/LiftoverVcfWrapper.java
@@ -1,7 +1,6 @@
 package org.labkey.sequenceanalysis.run.util;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.SequenceAnalysisService;
@@ -9,7 +8,6 @@ import org.labkey.api.sequenceanalysis.run.PicardWrapper;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Date;
 import java.util.List;
 
 /**

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/MarkDuplicatesWithMateCigarWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/MarkDuplicatesWithMateCigarWrapper.java
@@ -1,7 +1,6 @@
 package org.labkey.sequenceanalysis.run.util;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 /**
  * Created by bimber on 5/5/2016.

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/MergeBamAlignmentWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/MergeBamAlignmentWrapper.java
@@ -74,7 +74,7 @@ public class MergeBamAlignmentWrapper extends PicardWrapper
             try (SamReader reader = fact.open(alignedBam))
             {
                 SAMFileHeader header = reader.getFileHeader();
-                if (header.getReadGroups().size() == 0)
+                if (header.getReadGroups().isEmpty())
                 {
                     getLogger().warn("No read groups found in input BAM");
                 }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/MultiAllelicPositionWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/MultiAllelicPositionWrapper.java
@@ -1,7 +1,6 @@
 package org.labkey.sequenceanalysis.run.util;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.run.AbstractDiscvrSeqWrapper;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/NTSnp.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/NTSnp.java
@@ -37,7 +37,6 @@ public class NTSnp
 
     /**
      * 0-based, -1 indicates an insertion
-     * @return
      */
     public int getReferencePosition()
     {
@@ -46,7 +45,6 @@ public class NTSnp
 
     /**
      * 0-based, -1 indicates a deletion
-     * @return
      */
     public int getReadPosition()
     {
@@ -79,7 +77,6 @@ public class NTSnp
     /**
      * Returns the last reference position that was overlapped (0-based).  Primarily used for insertions relative to the reference,
      * in order to find the previous reference position.  For non-insertions, this will return the same value as getRefPosition()
-     * @return
      */
     public int getLastRefPosition()
     {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/PARalyzerRunner.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/PARalyzerRunner.java
@@ -2,7 +2,6 @@ package org.labkey.sequenceanalysis.run.util;
 
 import htsjdk.samtools.SAMFileHeader;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.pipeline.SamSorter;
@@ -38,7 +37,7 @@ public class PARalyzerRunner extends AbstractCommandWrapper
             setOutputDir(outDir);
 
             //ensure sort order
-            File bam = inputBam;
+            File bam;
             if (SequenceUtil.getBamSortOrder(inputBam) != SAMFileHeader.SortOrder.queryname)
             {
                 getLogger().info("Queryname Sorting BAM: " + inputBam.getPath());

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/RnaSeQCWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/RnaSeQCWrapper.java
@@ -4,7 +4,6 @@ import au.com.bytecode.opencsv.CSVWriter;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.pipeline.PipelineJobService;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/SFFExtractRunner.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/SFFExtractRunner.java
@@ -1,7 +1,6 @@
 package org.labkey.sequenceanalysis.run.util;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.util.FileUtil;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/SamFormatConverterWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/SamFormatConverterWrapper.java
@@ -2,7 +2,6 @@ package org.labkey.sequenceanalysis.run.util;
 
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.run.PicardWrapper;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/SortVcfWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/SortVcfWrapper.java
@@ -2,7 +2,6 @@ package org.labkey.sequenceanalysis.run.util;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.SequenceAnalysisService;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/SplitNCigarReadsWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/SplitNCigarReadsWrapper.java
@@ -2,7 +2,6 @@ package org.labkey.sequenceanalysis.run.util;
 
 import htsjdk.samtools.SAMFileHeader;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.pipeline.SamSorter;
 import org.labkey.api.sequenceanalysis.pipeline.SequencePipelineService;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/TabixRunner.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/TabixRunner.java
@@ -1,7 +1,6 @@
 package org.labkey.sequenceanalysis.run.util;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.pipeline.SequencePipelineService;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/VariantEvalWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/VariantEvalWrapper.java
@@ -2,7 +2,6 @@ package org.labkey.sequenceanalysis.run.util;
 
 import htsjdk.samtools.util.Interval;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.run.AbstractGatk4Wrapper;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/variant/DepthOfCoverageHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/variant/DepthOfCoverageHandler.java
@@ -131,20 +131,20 @@ public class DepthOfCoverageHandler extends AbstractParameterizedOutputHandler<S
                 extraArgs.addAll(DepthOfCoverageWrapper.generateIntervalArgsForFullGenome(rg, intervalList));
             }
 
-            Integer mmq = ctx.getParams().optInt("mmq");
+            int mmq = ctx.getParams().optInt("mmq");
             if (mmq > 0)
             {
                 extraArgs.add("--read-filter");
                 extraArgs.add("MappingQualityReadFilter");
                 extraArgs.add("--minimum-mapping-quality");
-                extraArgs.add(mmq.toString());
+                extraArgs.add(Integer.toString(mmq));
             }
 
-            Integer mbq = ctx.getParams().optInt("mbq");
+            int mbq = ctx.getParams().optInt("mbq");
             if (mbq > 0)
             {
                 extraArgs.add("--min-base-quality");
-                extraArgs.add(mbq.toString());
+                extraArgs.add(Integer.toString(mbq));
             }
 
             extraArgs.add("--omit-locus-table");

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/variant/GenotypeConcordanceStep.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/variant/GenotypeConcordanceStep.java
@@ -208,7 +208,7 @@ public class GenotypeConcordanceStep extends AbstractCommandPipelineStep<Variant
         }
     }
 
-    private class DiscordantTracker
+    private static class DiscordantTracker
     {
         long totalCompared = 0L;
         long totalDiscordant = 0L;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/variant/MultiAllelicPositionsHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/variant/MultiAllelicPositionsHandler.java
@@ -111,11 +111,11 @@ public class MultiAllelicPositionsHandler extends AbstractParameterizedOutputHan
             File outputFile = new File(ctx.getOutputDir(), basename + ".bed");
 
             List<String> options = new ArrayList<>();
-            Integer minDepth = ctx.getParams().optInt("minDepth", 0);
+            int minDepth = ctx.getParams().optInt("minDepth", 0);
             if (minDepth > 0)
             {
                 options.add("-minDepth");
-                options.add(minDepth.toString());
+                options.add(Integer.toString(minDepth));
             }
 
             MultiAllelicPositionWrapper wrapper = new MultiAllelicPositionWrapper(ctx.getLogger());
@@ -125,7 +125,7 @@ public class MultiAllelicPositionsHandler extends AbstractParameterizedOutputHan
                 throw new PipelineJobException("Unable to find expected file:" + outputFile.getPath());
             }
 
-            Integer callThreshold = ctx.getParams().optInt("callThreshold", 0);
+            int callThreshold = ctx.getParams().optInt("callThreshold", 0);
             if (callThreshold > 0)
             {
                 ctx.getLogger().info("will only report sites present in at least " + callThreshold + " samples");
@@ -140,7 +140,7 @@ public class MultiAllelicPositionsHandler extends AbstractParameterizedOutputHan
                         while ((line = reader.readNext()) != null)
                         {
                             totalLines++;
-                            Integer val = Integer.parseInt(line[4]);
+                            int val = Integer.parseInt(line[4]);
                             if (val < callThreshold)
                             {
                                 linesFiltered++;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/variant/SnpEffWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/variant/SnpEffWrapper.java
@@ -2,7 +2,6 @@ package org.labkey.sequenceanalysis.run.variant;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.pipeline.PipelineJobService;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/variant/SplitVcfBySamplesStep.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/variant/SplitVcfBySamplesStep.java
@@ -13,7 +13,6 @@ import org.labkey.api.sequenceanalysis.pipeline.PipelineContext;
 import org.labkey.api.sequenceanalysis.pipeline.PipelineStepProvider;
 import org.labkey.api.sequenceanalysis.pipeline.ReferenceGenome;
 import org.labkey.api.sequenceanalysis.pipeline.SequenceOutputHandler;
-import org.labkey.api.sequenceanalysis.pipeline.TaskFileManager;
 import org.labkey.api.sequenceanalysis.pipeline.ToolParameterDescriptor;
 import org.labkey.api.sequenceanalysis.pipeline.VariantProcessingStep;
 import org.labkey.api.sequenceanalysis.pipeline.VariantProcessingStepOutputImpl;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/variant/VariantQCWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/variant/VariantQCWrapper.java
@@ -1,7 +1,6 @@
 package org.labkey.sequenceanalysis.run.variant;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.run.AbstractDiscvrSeqWrapper;
 

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/util/AbstractSequenceMatcher.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/util/AbstractSequenceMatcher.java
@@ -5,7 +5,6 @@ import htsjdk.samtools.fastq.FastqRecord;
 import htsjdk.samtools.fastq.FastqWriter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.labkey.api.util.Pair;
 import org.labkey.sequenceanalysis.model.SequenceTag;
 
@@ -223,7 +222,7 @@ abstract public class AbstractSequenceMatcher
                 }
                 i++;
 
-                if (matches5.size() > 0)
+                if (!matches5.isEmpty())
                     break;
             }
         }
@@ -240,7 +239,7 @@ abstract public class AbstractSequenceMatcher
                 }
                 i++;
 
-                if (matches5.size() > 0)
+                if (!matches5.isEmpty())
                     break;
             }
         }
@@ -280,7 +279,7 @@ abstract public class AbstractSequenceMatcher
                 }
                 i++;
 
-                if (matches3.size() > 0)
+                if (!matches3.isEmpty())
                     break;
             }
         }
@@ -297,7 +296,7 @@ abstract public class AbstractSequenceMatcher
                 }
                 i++;
 
-                if (matches3.size() > 0)
+                if (!matches3.isEmpty())
                     break;
             }
         }
@@ -306,7 +305,7 @@ abstract public class AbstractSequenceMatcher
     protected SequenceMatch findBestMatch(Map<Integer, Map<String, SequenceMatch>> matchesMap, Map<String, Integer> counter)
     {
         SequenceMatch bestMatch = null;
-        if (matchesMap.size() > 0)
+        if (!matchesMap.isEmpty())
         {
             //get the match w/ the lowest edit distance
             Map<String, SequenceMatch> matches = matchesMap.get(matchesMap.keySet().iterator().next());
@@ -335,7 +334,7 @@ abstract public class AbstractSequenceMatcher
         return _createSummaryLog ? _summaryLog : null;
     }
 
-    protected class SequenceMatch
+    protected static class SequenceMatch
     {
         private final FastqRecord _rec;
         private final SequenceTag _tag;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/util/Barcoder.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/util/Barcoder.java
@@ -35,7 +35,6 @@ import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.text.NumberFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -277,7 +276,7 @@ public class Barcoder extends AbstractSequenceMatcher
             _logger.info("\tNo matches found");
         }
 
-        if (_otherMatches.size() > 0)
+        if (!_otherMatches.isEmpty())
         {
             _logger.info("Reads Not Matching A Readset:");
             for (String key : _otherMatches.keySet())
@@ -657,13 +656,13 @@ public class Barcoder extends AbstractSequenceMatcher
                     String mid5 = readname[0].split("-")[0];
                     String mid3 = readname[1].split("-")[0];
 
-                    Integer editDist5 = Integer.parseInt(readname[0].split("-")[1].substring(0, 1));
-                    Integer offset5 = Integer.parseInt(readname[0].split("-")[1].substring(1, 2));
-                    Integer deletion5 = Integer.parseInt(readname[0].split("-")[1].substring(2, 3));
+                    int editDist5 = Integer.parseInt(readname[0].split("-")[1].substring(0, 1));
+                    int offset5 = Integer.parseInt(readname[0].split("-")[1].substring(1, 2));
+                    int deletion5 = Integer.parseInt(readname[0].split("-")[1].substring(2, 3));
 
-                    Integer editDist3 = Integer.parseInt(readname[1].split("-")[1].substring(0, 1));
-                    Integer offset3 = Integer.parseInt(readname[1].split("-")[1].substring(1, 2));
-                    Integer deletion3 = Integer.parseInt(readname[1].split("-")[1].substring(2, 3));
+                    int editDist3 = Integer.parseInt(readname[1].split("-")[1].substring(0, 1));
+                    int offset3 = Integer.parseInt(readname[1].split("-")[1].substring(1, 2));
+                    int deletion3 = Integer.parseInt(readname[1].split("-")[1].substring(2, 3));
 
                     boolean shouldFindMid5 = editDist5 <= editDistance && offset5 <= offset && deletion5 <= deletions;
 
@@ -672,8 +671,8 @@ public class Barcoder extends AbstractSequenceMatcher
                     Assert.assertEquals("Incorrect 5' barcode on line: " + lineNum, (shouldFindMid5 ? mid5 : ""), line[2]);
                     Assert.assertEquals("Incorrect 3' barcode on line: " + lineNum, (shouldFindMid3 ? mid3 : ""), line[3]);
 
-                    Assert.assertEquals("Incorrect 5' editDistance on line: " + lineNum, (shouldFindMid5 ? editDist5.toString() : ""), line[4]);
-                    Assert.assertEquals("Incorrect 3' editDistance on line: " + lineNum, (shouldFindMid3 ? editDist3.toString() : ""), line[5]);
+                    Assert.assertEquals("Incorrect 5' editDistance on line: " + lineNum, (shouldFindMid5 ? Integer.toString(editDist5) : ""), line[4]);
+                    Assert.assertEquals("Incorrect 3' editDistance on line: " + lineNum, (shouldFindMid3 ? Integer.toString(editDist3) : ""), line[5]);
 
                     Integer barcodeLength = 10; //all barcodes are 10bp in this test
 
@@ -768,7 +767,7 @@ public class Barcoder extends AbstractSequenceMatcher
                     names.add(rs.getBarcode3());
             }
 
-            return BarcodeModel.getByNames(names.toArray(new String[names.size()]));
+            return BarcodeModel.getByNames(names.toArray(new String[0]));
         }
 
         private List<Readset> getReadsets()

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/util/ChainFileValidator.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/util/ChainFileValidator.java
@@ -77,7 +77,7 @@ public class ChainFileValidator
             List<String> errors = new ArrayList<>();
             while ((line = reader.readLine()) != null)
             {
-                if (line.equals("") || line.startsWith("#"))
+                if (line.isEmpty() || line.startsWith("#"))
                 {
                     continue;
                 }
@@ -292,7 +292,7 @@ public class ChainFileValidator
         {
             final Map<String, String> cachedReferences = new CaseInsensitiveHashMap<>();
             SqlSelector ss = new SqlSelector(DbScope.getLabKeyScope(), new SQLFragment("SELECT r.rowid, r.name, r.genbank, r.refSeqId, r.aliases FROM sequenceanalysis.ref_nt_sequences r WHERE r.rowid IN (SELECT ref_nt_id FROM sequenceanalysis.reference_library_members m WHERE m.library_id = ?) ", genomeId));
-            ss.forEach(new Selector.ForEachBlock<ResultSet>()
+            ss.forEach(new Selector.ForEachBlock<>()
             {
                 @Override
                 public void exec(ResultSet rs) throws SQLException
@@ -340,16 +340,16 @@ public class ChainFileValidator
             TableSelector ts = new TableSelector(SequenceAnalysisSchema.getTable(SequenceAnalysisSchema.TABLE_REF_LIBRARY_MEMBERS), PageFlowUtil.set("ref_nt_id", "alias"), filter, null);
             if (ts.exists())
             {
-                ts.forEachResults(new Selector.ForEachBlock<Results>()
-               {
-                   @Override
-                   public void exec(Results rs) throws SQLException
-                   {
-                       String name = RefNtSequenceModel.getForRowId(rs.getInt(FieldKey.fromString("ref_nt_id"))).getName();
-                       String alias = rs.getString(FieldKey.fromString("alias"));
-                       cachedReferences.put(alias, name);
-                   }
-               });
+                ts.forEachResults(new Selector.ForEachBlock<>()
+                {
+                    @Override
+                    public void exec(Results rs) throws SQLException
+                    {
+                        String name = RefNtSequenceModel.getForRowId(rs.getInt(FieldKey.fromString("ref_nt_id"))).getName();
+                        String alias = rs.getString(FieldKey.fromString("alias"));
+                        cachedReferences.put(alias, name);
+                    }
+                });
             }
 
             _cachedReferencesByGenome.put(genomeId, cachedReferences);

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/util/CreateUnalignedFastq.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/util/CreateUnalignedFastq.java
@@ -8,7 +8,6 @@ import htsjdk.samtools.fastq.FastqRecord;
 import htsjdk.samtools.fastq.FastqWriter;
 import htsjdk.samtools.fastq.FastqWriterFactory;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.Pair;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/util/FastaToFastqConverter.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/util/FastaToFastqConverter.java
@@ -6,7 +6,6 @@ import htsjdk.samtools.fastq.FastqWriterFactory;
 import htsjdk.samtools.reference.FastaSequenceFile;
 import htsjdk.samtools.reference.ReferenceSequence;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 import java.io.File;
 

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/util/FastqMerger.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/util/FastqMerger.java
@@ -3,7 +3,6 @@ package org.labkey.sequenceanalysis.util;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.reader.Readers;
 import org.labkey.api.sequenceanalysis.run.SimpleScriptWrapper;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/util/FastqToFastaConverter.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/util/FastqToFastaConverter.java
@@ -4,7 +4,6 @@ import htsjdk.samtools.fastq.FastqReader;
 import htsjdk.samtools.fastq.FastqRecord;
 import htsjdk.samtools.util.IOUtil;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.labkey.api.pipeline.PipelineJobException;
 
 import java.io.BufferedWriter;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/util/FastqUtils.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/util/FastqUtils.java
@@ -23,7 +23,6 @@ import org.apache.commons.io.Charsets;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.util.FileType;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/util/MultiFeatureIterator.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/util/MultiFeatureIterator.java
@@ -34,7 +34,7 @@ public class MultiFeatureIterator<TYPE extends Feature> implements AutoCloseable
 
         for (FeatureReader<TYPE> reader : readers)
         {
-            _queue.add(new ComparableFeatureIterator<TYPE>(reader.iterator(), comparator));
+            _queue.add(new ComparableFeatureIterator<>(reader.iterator(), comparator));
         }
     }
 
@@ -52,7 +52,7 @@ public class MultiFeatureIterator<TYPE extends Feature> implements AutoCloseable
 
         for (final Iterator<TYPE> iterator : _iterators)
         {
-            addIfNotEmpty(new ComparableFeatureIterator<TYPE>(iterator, _comparator));
+            addIfNotEmpty(new ComparableFeatureIterator<>(iterator, _comparator));
         }
 
         _initialized = true;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/util/ReferenceLibraryHelperImpl.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/util/ReferenceLibraryHelperImpl.java
@@ -1,7 +1,6 @@
 package org.labkey.sequenceanalysis.util;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.reader.Readers;
 import org.labkey.api.sequenceanalysis.ReferenceLibraryHelper;
@@ -21,7 +20,7 @@ import java.util.Map;
 public class ReferenceLibraryHelperImpl implements ReferenceLibraryHelper
 {
     private final File _refFasta;
-    private Logger _log = null;
+    private Logger _log;
     private final Map<String, Integer> _cachedIds = new HashMap<>();
     private final Map<String, String> _cachedAccessions = new HashMap<>();
 

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/util/TranslatingReferenceSequence.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/util/TranslatingReferenceSequence.java
@@ -71,8 +71,6 @@ public class TranslatingReferenceSequence
 
     /**
      *
-     * @param readSnps
-     * @return
      */
     public List<AASnp> translateSnpsForRead(Map<Integer, List<NTSnp>> readSnps)
     {
@@ -233,7 +231,7 @@ public class TranslatingReferenceSequence
                     StringBuilder codon = new StringBuilder();
 
                     //to track the SNPs that comprise this codon, 0-based
-                    Map<Integer, NTSnp> snpMap = new HashMap<Integer, NTSnp>();
+                    Map<Integer, NTSnp> snpMap = new HashMap<>();
                     Integer positionInCodon = null; //0-based
                     for (Integer p : positions) //1-based
                     {
@@ -242,7 +240,7 @@ public class TranslatingReferenceSequence
                         {
                             StringBuilder thisSegment = new StringBuilder();
                             int positionInSegment = 0;
-                            Map<Integer, NTSnp> snpMapForSegment = new HashMap<Integer, NTSnp>(); //0-based
+                            Map<Integer, NTSnp> snpMapForSegment = new HashMap<>(); //0-based
 
                             //force sorting by idx
                             List<NTSnp> otherSnps = readSnps.get(position);
@@ -300,7 +298,7 @@ public class TranslatingReferenceSequence
                     assert positionInCodon != null;
                     if (codon.length() <= 4)
                     {
-                        List<NTSnp> snpList = new ArrayList<NTSnp>(snpMap.values());
+                        List<NTSnp> snpList = new ArrayList<>(snpMap.values());
                         snps.add(new AASnp(pi, model, aaPosInProtein, 0, codon.toString(), frame, snpList, _nt.getSequenceBases()));
                     }
                     else
@@ -309,7 +307,7 @@ public class TranslatingReferenceSequence
                         int start = aaInsertIndex * 3;
                         int stop = (codon.length() - start) <= 4 ? codon.length() : start + 3;
                         String tmpCodon = codon.substring(start, stop);
-                        List<NTSnp> snpList = new ArrayList<NTSnp>();
+                        List<NTSnp> snpList = new ArrayList<>();
                         for (int j = start; j<stop; j++)
                         {
                             if (snpMap.containsKey(j))

--- a/SequenceAnalysis/test/src/org/labkey/test/tests/external/labModules/SequenceTest.java
+++ b/SequenceAnalysis/test/src/org/labkey/test/tests/external/labModules/SequenceTest.java
@@ -361,7 +361,6 @@ public class SequenceTest extends BaseWebDriverTest
      * created properly.  It also exercises various features associated with the readset grid, including
      * the FASTQC report and downloading of results
      *
-     * @throws Exception
      */
     private void readsetFeaturesTest() throws IOException
     {
@@ -1675,7 +1674,7 @@ public class SequenceTest extends BaseWebDriverTest
         sr.setColumns(Arrays.asList("dataid/DataFileUrl", "rowid"));
         SelectRowsResponse srr = sr.execute(cn, getProjectName());
         File existing = new File(URI.create(srr.getRows().get(0).get("dataid/DataFileUrl").toString()));
-        Integer rowId = Integer.valueOf(srr.getRows().get(0).get("rowid").toString());
+        int rowId = Integer.parseInt(srr.getRows().get(0).get("rowid").toString());
 
         Assert.assertTrue("File does not exist: " + existing.getPath(), existing.exists());
         Assert.assertEquals("Expected one row", 1, srr.getRowCount().intValue());
@@ -1707,7 +1706,7 @@ public class SequenceTest extends BaseWebDriverTest
         SelectRowsResponse srr2 = sr2.execute(cn, getProjectName());
         if (srr2.getRowCount().intValue() > 0)
         {
-            Integer rowId2 = Integer.valueOf(srr.getRows().get(0).get("rowid").toString());
+            int rowId2 = Integer.parseInt(srr.getRows().get(0).get("rowid").toString());
             log("initial rowId: " + rowId + ", after: " + rowId2);
         }
 

--- a/Studies/test/src/org/labkey/test/tests/studies/StudiesTest.java
+++ b/Studies/test/src/org/labkey/test/tests/studies/StudiesTest.java
@@ -23,7 +23,7 @@ public class StudiesTest extends BaseWebDriverTest
     @BeforeClass
     public static void setupProject()
     {
-        StudiesTest init = (StudiesTest)getCurrentTest();
+        StudiesTest init = getCurrentTest();
 
         init.doSetup();
     }

--- a/blast/src/org/labkey/blast/BLASTController.java
+++ b/blast/src/org/labkey/blast/BLASTController.java
@@ -88,7 +88,7 @@ public class BLASTController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class GetSettingsAction extends ReadOnlyApiAction<Object>
+    public static class GetSettingsAction extends ReadOnlyApiAction<Object>
     {
         @Override
         public ApiResponse execute(Object form, BindException errors)
@@ -104,7 +104,7 @@ public class BLASTController extends SpringActionController
     }
 
     @RequiresSiteAdmin
-    public class SetSettingsAction extends MutatingApiAction<SettingsForm>
+    public static class SetSettingsAction extends MutatingApiAction<SettingsForm>
     {
         @Override
         public ApiResponse execute(SettingsForm form, BindException errors)
@@ -150,7 +150,7 @@ public class BLASTController extends SpringActionController
     }
 
     @RequiresPermission(InsertPermission.class)
-    public class CreateDatabaseAction extends MutatingApiAction<DatabaseForm>
+    public static class CreateDatabaseAction extends MutatingApiAction<DatabaseForm>
     {
         @Override
         public ApiResponse execute(DatabaseForm form, BindException errors)
@@ -179,7 +179,7 @@ public class BLASTController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class RunBlastAction extends AbstractFileUploadAction<RunBlastForm>
+    public static class RunBlastAction extends AbstractFileUploadAction<RunBlastForm>
     {
         @Override
         protected void setContentType(HttpServletResponse response)
@@ -467,7 +467,7 @@ public class BLASTController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class RecreateDatabaseAction extends MutatingApiAction<RecreateDatabaseForm>
+    public static class RecreateDatabaseAction extends MutatingApiAction<RecreateDatabaseForm>
     {
         @Override
         public ApiResponse execute(RecreateDatabaseForm form, BindException errors)
@@ -530,7 +530,7 @@ public class BLASTController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class JobDetailsAction extends SimpleViewAction<BlastResultForm>
+    public static class JobDetailsAction extends SimpleViewAction<BlastResultForm>
     {
         @Override
         public ModelAndView getView(BlastResultForm form, BindException errors) throws Exception
@@ -571,7 +571,7 @@ public class BLASTController extends SpringActionController
 
     @RequiresPermission(ReadPermission.class)
     @IgnoresTermsOfUse
-    public class DownloadBlastResultsAction extends ExportAction<DownloadBlastResultsForm>
+    public static class DownloadBlastResultsAction extends ExportAction<DownloadBlastResultsForm>
     {
         @Override
         public void export(DownloadBlastResultsForm form, HttpServletResponse response, BindException errors) throws Exception

--- a/blast/src/org/labkey/blast/BLASTMaintenanceTask.java
+++ b/blast/src/org/labkey/blast/BLASTMaintenanceTask.java
@@ -1,7 +1,6 @@
 package org.labkey.blast;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.apache.tomcat.util.http.fileupload.FileUtils;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.Container;

--- a/blast/src/org/labkey/blast/BLASTUpgradeCode.java
+++ b/blast/src/org/labkey/blast/BLASTUpgradeCode.java
@@ -5,7 +5,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
-import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.PropertyManager;
 import org.labkey.api.data.SQLFragment;
@@ -17,12 +16,9 @@ import org.labkey.api.data.UpgradeCode;
 import org.labkey.api.module.ModuleContext;
 import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.query.FieldKey;
-import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.PageFlowUtil;
-import org.labkey.blast.model.BlastJob;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 

--- a/blast/src/org/labkey/blast/BlastGenomeTrigger.java
+++ b/blast/src/org/labkey/blast/BlastGenomeTrigger.java
@@ -1,7 +1,6 @@
 package org.labkey.blast;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.SimpleFilter;

--- a/blast/src/org/labkey/blast/button/CreateDatabaseButton.java
+++ b/blast/src/org/labkey/blast/button/CreateDatabaseButton.java
@@ -5,7 +5,6 @@ import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.view.template.ClientDependency;
 import org.labkey.blast.BLASTModule;
 
-import java.util.Arrays;
 import java.util.List;
 
 /**

--- a/blast/src/org/labkey/blast/model/BlastJob.java
+++ b/blast/src/org/labkey/blast/model/BlastJob.java
@@ -375,7 +375,7 @@ public class BlastJob implements Serializable
                 }
             }
 
-            class Alignment
+            static class Alignment
             {
                 final int qLength;
                 final int sLength;

--- a/blast/src/org/labkey/blast/pipeline/BlastDatabaseTask.java
+++ b/blast/src/org/labkey/blast/pipeline/BlastDatabaseTask.java
@@ -32,7 +32,6 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 

--- a/blast/src/org/labkey/blast/pipeline/BlastFinalTask.java
+++ b/blast/src/org/labkey/blast/pipeline/BlastFinalTask.java
@@ -19,13 +19,9 @@ import org.labkey.api.pipeline.AbstractTaskFactory;
 import org.labkey.api.pipeline.AbstractTaskFactorySettings;
 import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.pipeline.PipelineJobException;
-import org.labkey.api.pipeline.RecordedAction;
 import org.labkey.api.pipeline.RecordedActionSet;
 import org.labkey.api.util.FileType;
-import org.labkey.blast.BLASTWrapper;
 
-import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 

--- a/blast/src/org/labkey/blast/pipeline/BlastWorkTask.java
+++ b/blast/src/org/labkey/blast/pipeline/BlastWorkTask.java
@@ -25,7 +25,6 @@ import org.labkey.api.util.FileType;
 import org.labkey.blast.BLASTWrapper;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 

--- a/cluster/api-src/org/labkey/api/cluster/ClusterService.java
+++ b/cluster/api-src/org/labkey/api/cluster/ClusterService.java
@@ -1,7 +1,6 @@
 package org.labkey.api.cluster;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.labkey.api.data.Container;
 import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.pipeline.PipelineValidationException;

--- a/cluster/src/org/labkey/cluster/ClusterController.java
+++ b/cluster/src/org/labkey/cluster/ClusterController.java
@@ -107,7 +107,7 @@ public class ClusterController extends SpringActionController
     }
 
     @RequiresSiteAdmin
-    public class ForcePipelineCancelAction extends ConfirmAction<JobIdsForm>
+    public static class ForcePipelineCancelAction extends ConfirmAction<JobIdsForm>
     {
         @Override
         public void validateCommand(JobIdsForm form, Errors errors)
@@ -213,7 +213,7 @@ public class ClusterController extends SpringActionController
     }
 
     @RequiresSiteAdmin
-    public class ResetPipelineJobLogFileAction extends ConfirmAction<ResetPipelineJobLogFileForm>
+    public static class ResetPipelineJobLogFileAction extends ConfirmAction<ResetPipelineJobLogFileForm>
     {
         @Override
         public void validateCommand(ResetPipelineJobLogFileForm form, Errors errors)

--- a/cluster/src/org/labkey/cluster/pipeline/AbstractClusterExecutionEngine.java
+++ b/cluster/src/org/labkey/cluster/pipeline/AbstractClusterExecutionEngine.java
@@ -3,7 +3,6 @@ package org.labkey.cluster.pipeline;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashSet;

--- a/cluster/src/org/labkey/cluster/pipeline/HTCondorExecutionEngineConfig.java
+++ b/cluster/src/org/labkey/cluster/pipeline/HTCondorExecutionEngineConfig.java
@@ -1,11 +1,6 @@
 package org.labkey.cluster.pipeline;
 
 import org.jetbrains.annotations.NotNull;
-import org.labkey.api.util.StringExpression;
-import org.labkey.api.util.StringExpressionFactory;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Created by bimber on 10/31/2015.

--- a/cluster/src/org/labkey/cluster/pipeline/SlurmExecutionEngine.java
+++ b/cluster/src/org/labkey/cluster/pipeline/SlurmExecutionEngine.java
@@ -124,7 +124,7 @@ public class SlurmExecutionEngine extends AbstractClusterExecutionEngine<SlurmEx
         {
             //verify success
             boolean headerFound = false;
-            List<String> header = null;
+            List<String> header;
             int jobIdx = -1;
             int stateIdx = -1;
             int hostnameIdx = -1;
@@ -721,7 +721,7 @@ public class SlurmExecutionEngine extends AbstractClusterExecutionEngine<SlurmEx
         if (ret != null)
         {
             boolean headerFound = false;
-            List<String> header = null;
+            List<String> header;
             int jobIdx = -1;
             int stateIdx = -1;
             int hostnameIdx = -1;

--- a/cluster/src/org/labkey/cluster/pipeline/TestCase.java
+++ b/cluster/src/org/labkey/cluster/pipeline/TestCase.java
@@ -113,7 +113,7 @@ public class TestCase extends Assert
 
     public static class TestRunner implements ClusterService.ClusterRemoteTask
     {
-        public long _sleep = 0l;
+        public long _sleep;
 
         public TestRunner(long sleep)
         {

--- a/discvrcore/src/org/labkey/discvrcore/AuditSummaryUserSchema.java
+++ b/discvrcore/src/org/labkey/discvrcore/AuditSummaryUserSchema.java
@@ -236,13 +236,13 @@ public class AuditSummaryUserSchema extends SimpleUserSchema
             TableInfo qa = QueryService.get().getUserSchema(TestContext.get().getUser(), c, NAME).getTable(DATASET_AUDIT);
 
             TableSelector ts1 = new TableSelector(qa, PageFlowUtil.set("primaryKey"));
-            assertEquals("Incorrect row count", ts1.getRowCount(), 2L);
+            assertEquals("Incorrect row count", 2L, ts1.getRowCount());
 
             assertEquals("Incorrect PK", new TableSelector(qa, PageFlowUtil.set("primaryKey"), new SimpleFilter(FieldKey.fromString("Comment"), "inserted", CompareType.CONTAINS).addCondition(FieldKey.fromString("DatasetId"), d1.getDatasetId()), null).getObject(String.class), guid1);
-            assertEquals("Incorrect PK", new TableSelector(qa, PageFlowUtil.set("primaryKey"), new SimpleFilter(FieldKey.fromString("Comment"), "inserted", CompareType.CONTAINS).addCondition(FieldKey.fromString("DatasetId"), d2.getDatasetId()), null).getObject(String.class), "P1");
+            assertEquals("Incorrect PK", "P1", new TableSelector(qa, PageFlowUtil.set("primaryKey"), new SimpleFilter(FieldKey.fromString("Comment"), "inserted", CompareType.CONTAINS).addCondition(FieldKey.fromString("DatasetId"), d2.getDatasetId()), null).getObject(String.class));
 
             assertEquals("Incorrect PK", new TableSelector(qa, PageFlowUtil.set("primaryKey"), new SimpleFilter(FieldKey.fromString("Comment"), "inserted", CompareType.CONTAINS).addCondition(FieldKey.fromString("DatasetId/Name"), d1.getName()), null).getObject(String.class), guid1);
-            assertEquals("Incorrect PK", new TableSelector(qa, PageFlowUtil.set("primaryKey"), new SimpleFilter(FieldKey.fromString("Comment"), "inserted", CompareType.CONTAINS).addCondition(FieldKey.fromString("DatasetId/Name"), d2.getName()), null).getObject(String.class), "P1");
+            assertEquals("Incorrect PK", "P1", new TableSelector(qa, PageFlowUtil.set("primaryKey"), new SimpleFilter(FieldKey.fromString("Comment"), "inserted", CompareType.CONTAINS).addCondition(FieldKey.fromString("DatasetId/Name"), d2.getName()), null).getObject(String.class));
 
             t1.getUpdateService().deleteRows(TestContext.get().getUser(), c, Collections.singletonList(new CaseInsensitiveHashMap<>(Map.of("ObjectId", guid1))), null, null);
             assertEquals("Incorrect PK", new TableSelector(qa, PageFlowUtil.set("primaryKey"), new SimpleFilter(FieldKey.fromString("Comment"), "deleted", CompareType.CONTAINS), null).getObject(String.class), guid1);
@@ -251,7 +251,7 @@ public class AuditSummaryUserSchema extends SimpleUserSchema
             User reader = getReaderUser(true);
             qa = QueryService.get().getUserSchema(reader, c, NAME).getTable(DATASET_AUDIT);
             assertEquals("Incorrect PK", new TableSelector(qa, PageFlowUtil.set("primaryKey"), new SimpleFilter(FieldKey.fromString("Comment"), "inserted", CompareType.CONTAINS).addCondition(FieldKey.fromString("DatasetId/Name"), d1.getName()), null).getObject(String.class), guid1);
-            assertEquals("Incorrect PK", new TableSelector(qa, PageFlowUtil.set("primaryKey"), new SimpleFilter(FieldKey.fromString("Comment"), "inserted", CompareType.CONTAINS).addCondition(FieldKey.fromString("DatasetId/Name"), d2.getName()), null).getObject(String.class), "P1");
+            assertEquals("Incorrect PK", "P1", new TableSelector(qa, PageFlowUtil.set("primaryKey"), new SimpleFilter(FieldKey.fromString("Comment"), "inserted", CompareType.CONTAINS).addCondition(FieldKey.fromString("DatasetId/Name"), d2.getName()), null).getObject(String.class));
         }
 
         @AfterClass

--- a/discvrcore/test/src/org/labkey/test/tests/discvrcore/DiscvrCoreTest.java
+++ b/discvrcore/test/src/org/labkey/test/tests/discvrcore/DiscvrCoreTest.java
@@ -27,8 +27,6 @@ import org.labkey.test.categories.InDevelopment;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.*;
-
 @Category({InDevelopment.class})
 public class DiscvrCoreTest extends BaseWebDriverTest
 {
@@ -41,7 +39,7 @@ public class DiscvrCoreTest extends BaseWebDriverTest
     @BeforeClass
     public static void setupProject()
     {
-        DiscvrCoreTest init = (DiscvrCoreTest)getCurrentTest();
+        DiscvrCoreTest init = getCurrentTest();
 
         init.doSetup();
     }

--- a/jbrowse/api-src/org/labkey/api/jbrowse/JBrowseFieldCustomizer.java
+++ b/jbrowse/api-src/org/labkey/api/jbrowse/JBrowseFieldCustomizer.java
@@ -7,9 +7,9 @@ import java.util.Collection;
 import java.util.List;
 
 public interface JBrowseFieldCustomizer {
-    public void customizeField(JBrowseFieldDescriptor field, Container c, User u);
+    void customizeField(JBrowseFieldDescriptor field, Container c, User u);
 
-    public List<String> getPromotedFilters(Collection<String> indexedFields, Container c, User u);
+    List<String> getPromotedFilters(Collection<String> indexedFields, Container c, User u);
 
-    public boolean isAvailable(Container c, User u);
+    boolean isAvailable(Container c, User u);
 }

--- a/jbrowse/api-src/org/labkey/api/jbrowse/JBrowseFieldDescriptor.java
+++ b/jbrowse/api-src/org/labkey/api/jbrowse/JBrowseFieldDescriptor.java
@@ -18,7 +18,7 @@ public class JBrowseFieldDescriptor {
     private List<String> _allowableValues = null;
     private boolean _isHidden = false;
     private String _colWidth = null;
-    private Integer _orderKey = 8;
+    private Integer _orderKey;
 
     // NOTE: this should support "jexl:xxxxxx" syntax, like other JBrowse formatting
     private String _formatString = null;

--- a/jbrowse/src/org/labkey/jbrowse/JBrowseGenomeTrigger.java
+++ b/jbrowse/src/org/labkey/jbrowse/JBrowseGenomeTrigger.java
@@ -3,7 +3,6 @@ package org.labkey.jbrowse;
 import org.apache.logging.log4j.Logger;
 import org.labkey.api.data.Container;
 import org.labkey.api.module.ModuleLoader;
-import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.security.User;
 import org.labkey.api.sequenceanalysis.GenomeTrigger;
 

--- a/jbrowse/src/org/labkey/jbrowse/JBrowseLuceneSearch.java
+++ b/jbrowse/src/org/labkey/jbrowse/JBrowseLuceneSearch.java
@@ -261,7 +261,7 @@ public class JBrowseLuceneSearch
         while (tokenizer.hasMoreTokens() && !searchString.equals(ALL_DOCS))
         {
             String queryString = tokenizer.nextToken();
-            Query query = null;
+            Query query;
 
             String fieldName = extractFieldName(queryString);
 
@@ -693,7 +693,7 @@ public class JBrowseLuceneSearch
         }
     }
 
-    private class SearchConfig {
+    private static class SearchConfig {
         CacheEntry cacheEntry;
         Query query;
         int pageSize;

--- a/jbrowse/src/org/labkey/jbrowse/JBrowseManager.java
+++ b/jbrowse/src/org/labkey/jbrowse/JBrowseManager.java
@@ -48,7 +48,6 @@ import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.Path;
 import org.labkey.api.view.UnauthorizedException;
 import org.labkey.jbrowse.model.JBrowseSession;
-import org.labkey.jbrowse.model.JsonFile;
 import org.labkey.jbrowse.pipeline.JBrowseSessionPipelineJob;
 
 import java.io.File;
@@ -58,7 +57,6 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class JBrowseManager
 {
@@ -187,7 +185,7 @@ public class JBrowseManager
             throw new PipelineJobException("Unable to find expected folder: " + toolDir.getPath());
         }
 
-        File exe = null;
+        File exe;
         if (SystemUtils.IS_OS_WINDOWS)
         {
             exe = new File(toolDir, "cli-win.exe");

--- a/jbrowse/src/org/labkey/jbrowse/JBrowseSequenceOutputHandler.java
+++ b/jbrowse/src/org/labkey/jbrowse/JBrowseSequenceOutputHandler.java
@@ -14,7 +14,6 @@ import org.labkey.api.sequenceanalysis.pipeline.SequenceOutputHandler;
 import org.labkey.api.view.ActionURL;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 
@@ -100,7 +99,7 @@ public class JBrowseSequenceOutputHandler implements SequenceOutputHandler<Seque
         return false;
     }
 
-    public class Processor implements SequenceOutputProcessor
+    public static class Processor implements SequenceOutputProcessor
     {
         @Override
         public void processFilesOnWebserver(PipelineJob job, SequenceAnalysisJobSupport support, List<SequenceOutputFile> inputFiles, JSONObject params, File outputDir, List<RecordedAction> actions, List<SequenceOutputFile> outputsToCreate) throws UnsupportedOperationException, PipelineJobException

--- a/jbrowse/src/org/labkey/jbrowse/JBrowseServiceImpl.java
+++ b/jbrowse/src/org/labkey/jbrowse/JBrowseServiceImpl.java
@@ -178,10 +178,6 @@ public class JBrowseServiceImpl extends JBrowseService
     }
 
     /***
-     * @param groupName
-     * @param u
-     * @param c
-     * @return
      */
     public List<String> resolveGroups(String trackId, String groupName, User u, Container c)
     {

--- a/jbrowse/src/org/labkey/jbrowse/button/AddDataButton.java
+++ b/jbrowse/src/org/labkey/jbrowse/button/AddDataButton.java
@@ -6,7 +6,6 @@ import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.view.template.ClientDependency;
 import org.labkey.jbrowse.JBrowseModule;
 
-import java.util.Arrays;
 import java.util.List;
 
 /**

--- a/jbrowse/src/org/labkey/jbrowse/button/AddLibraryButton.java
+++ b/jbrowse/src/org/labkey/jbrowse/button/AddLibraryButton.java
@@ -6,7 +6,6 @@ import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.view.template.ClientDependency;
 import org.labkey.jbrowse.JBrowseModule;
 
-import java.util.Arrays;
 import java.util.List;
 
 /**

--- a/jbrowse/src/org/labkey/jbrowse/button/AddTrackButton.java
+++ b/jbrowse/src/org/labkey/jbrowse/button/AddTrackButton.java
@@ -6,7 +6,6 @@ import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.view.template.ClientDependency;
 import org.labkey.jbrowse.JBrowseModule;
 
-import java.util.Arrays;
 import java.util.List;
 
 /**

--- a/jbrowse/src/org/labkey/jbrowse/button/ModifyTrackConfigButton.java
+++ b/jbrowse/src/org/labkey/jbrowse/button/ModifyTrackConfigButton.java
@@ -6,7 +6,6 @@ import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.view.template.ClientDependency;
 import org.labkey.jbrowse.JBrowseModule;
 
-import java.util.Arrays;
 import java.util.List;
 
 /**

--- a/jbrowse/src/org/labkey/jbrowse/button/ReprocessResourcesButton.java
+++ b/jbrowse/src/org/labkey/jbrowse/button/ReprocessResourcesButton.java
@@ -6,7 +6,6 @@ import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.view.template.ClientDependency;
 import org.labkey.jbrowse.JBrowseModule;
 
-import java.util.Arrays;
 import java.util.List;
 
 /**

--- a/jbrowse/src/org/labkey/jbrowse/button/ReprocessSessionsButton.java
+++ b/jbrowse/src/org/labkey/jbrowse/button/ReprocessSessionsButton.java
@@ -6,7 +6,6 @@ import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.view.template.ClientDependency;
 import org.labkey.jbrowse.JBrowseModule;
 
-import java.util.Arrays;
 import java.util.List;
 
 /**

--- a/jbrowse/src/org/labkey/jbrowse/model/JBrowseSession.java
+++ b/jbrowse/src/org/labkey/jbrowse/model/JBrowseSession.java
@@ -28,7 +28,6 @@ import org.labkey.api.util.PageFlowUtil;
 import org.labkey.jbrowse.JBrowseManager;
 import org.labkey.jbrowse.JBrowseSchema;
 
-import java.io.File;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/jbrowse/src/org/labkey/jbrowse/pipeline/JBrowseSessionTask.java
+++ b/jbrowse/src/org/labkey/jbrowse/pipeline/JBrowseSessionTask.java
@@ -39,7 +39,6 @@ import org.labkey.jbrowse.model.JBrowseSession;
 import org.labkey.jbrowse.model.JsonFile;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;

--- a/jbrowse/test/src/org/labkey/test/tests/external/labModules/JBrowseTest.java
+++ b/jbrowse/test/src/org/labkey/test/tests/external/labModules/JBrowseTest.java
@@ -1954,25 +1954,25 @@ public class JBrowseTest extends BaseWebDriverTest
             switch(elem.getAttribute("aria-colindex"))
             {
                 case "1":
-                    Assert.assertEquals(value, "1");
+                    Assert.assertEquals("1", value);
                     break;
                 case "2":
-                    Assert.assertEquals(value, "2");
+                    Assert.assertEquals("2", value);
                     break;
                 case "3":
-                    Assert.assertEquals(value, "A");
+                    Assert.assertEquals("A", value);
                     break;
                 case "4":
-                    Assert.assertEquals(value, "T");
+                    Assert.assertEquals("T", value);
                     break;
                 case "6":
-                    Assert.assertEquals(value, "0.029");
+                    Assert.assertEquals("0.029", value);
                     break;
                 case "7":
-                    Assert.assertEquals(value, "7.292");
+                    Assert.assertEquals("7.292", value);
                     break;
                 case "8":
-                    Assert.assertEquals(value, "HIGH");
+                    Assert.assertEquals("HIGH", value);
                     break;
             }
         }
@@ -1997,19 +1997,19 @@ public class JBrowseTest extends BaseWebDriverTest
         parentOfCaddScoreToggle.click();
 
         String colVisModelString = "%257B%2522contig%2522%253Atrue%252C%2522start%2522%253Atrue%252C%2522ref%2522%253Atrue%252C%2522alt%2522%253Atrue%252C%2522variableSamples%2522%253Atrue%252C%2522AF%2522%253Atrue%252C%2522CADD_PH%2522%253Atrue%252C%2522IMPACT%2522%253Atrue%257D";
-        Assert.assertEquals(getUrlParam("colVisModel"), colVisModelString);
+        Assert.assertEquals(colVisModelString, getUrlParam("colVisModel"));
 
         getDriver().navigate().refresh();
 
         waitForElement(TOP_ROW);
-        Assert.assertEquals(getUrlParam("colVisModel"), colVisModelString);
+        Assert.assertEquals(colVisModelString, getUrlParam("colVisModel"));
         testLuceneColumnSerializationFirstRow();
 
         waitAndClick(Locator.tagWithText("button", "Search"));
         waitAndClick(Locator.tagWithClass("button", "filter-form-select-button"));
 
         waitForElement(TOP_ROW);
-        Assert.assertEquals(getUrlParam("colVisModel"), colVisModelString);
+        Assert.assertEquals(colVisModelString, getUrlParam("colVisModel"));
         testLuceneColumnSerializationFirstRow();
     }
 }

--- a/jbrowse/test/src/org/labkey/test/tests/external/labModules/JBrowseTestHelper.java
+++ b/jbrowse/test/src/org/labkey/test/tests/external/labModules/JBrowseTestHelper.java
@@ -6,7 +6,6 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.WebDriverWrapper;
-import org.labkey.test.categories.Base;
 import org.labkey.test.components.ext4.Window;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;

--- a/singlecell/api-src/org/labkey/api/singlecell/pipeline/SingleCellStep.java
+++ b/singlecell/api-src/org/labkey/api/singlecell/pipeline/SingleCellStep.java
@@ -1,18 +1,5 @@
 package org.labkey.api.singlecell.pipeline;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.jetbrains.annotations.Nullable;
-import org.labkey.api.pipeline.PipelineJobException;
-import org.labkey.api.sequenceanalysis.SequenceOutputFile;
-import org.labkey.api.sequenceanalysis.pipeline.PipelineStep;
-import org.labkey.api.sequenceanalysis.pipeline.PipelineStepOutput;
-import org.labkey.api.sequenceanalysis.pipeline.SequenceOutputHandler;
-
-import java.io.File;
-import java.io.Serializable;
-import java.util.Collection;
-import java.util.List;
-
 public interface SingleCellStep extends AbstractSingleCellStep
 {
     String STEP_TYPE = "singleCell";

--- a/singlecell/src/org/labkey/singlecell/CellHashingServiceImpl.java
+++ b/singlecell/src/org/labkey/singlecell/CellHashingServiceImpl.java
@@ -913,7 +913,7 @@ public class CellHashingServiceImpl extends CellHashingService
                         description.append(StringUtils.trimToNull(so.getDescription()));
                     }
 
-                    String delim = description.length() > 0 ? "\n" : "";
+                    String delim = !description.isEmpty() ? "\n" : "";
 
                     DecimalFormat fmt = new DecimalFormat("##.##%");
                     List<String> metricNames = new ArrayList<>(Arrays.asList("PassingCellBarcodes", "TotalLowCounts", "TotalSinglet", "FractionCalled", "FractionSinglet", "FractionDoublet", "FractionDiscordant", "UniqueHtos"));

--- a/singlecell/src/org/labkey/singlecell/analysis/AbstractSingleCellHandler.java
+++ b/singlecell/src/org/labkey/singlecell/analysis/AbstractSingleCellHandler.java
@@ -36,7 +36,6 @@ import org.labkey.api.sequenceanalysis.pipeline.SequencePipelineService;
 import org.labkey.api.sequenceanalysis.pipeline.ToolParameterDescriptor;
 import org.labkey.api.singlecell.CellHashingService;
 import org.labkey.api.singlecell.pipeline.AbstractSingleCellPipelineStep;
-import org.labkey.api.singlecell.pipeline.AbstractSingleCellStep;
 import org.labkey.api.singlecell.pipeline.SingleCellRawDataStep;
 import org.labkey.api.singlecell.pipeline.SingleCellStep;
 import org.labkey.api.util.FileUtil;

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/AppendCiteSeq.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/AppendCiteSeq.java
@@ -94,7 +94,7 @@ public class AppendCiteSeq extends AbstractCellHashingCiteseqStep
         for (SeuratObjectWrapper wrapper : inputObjects)
         {
             File localCopyUmiCountDir = null;
-            File localAggregateCountFile = null;
+            File localAggregateCountFile;
             if (wrapper.getSequenceOutputFileId() == null)
             {
                 throw new PipelineJobException("Append CITE-seq is only support using seurat objects will a single input dataset. Consider moving this step easier in your pipeline, before merging or subsetting");

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/AppendMetadata.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/AppendMetadata.java
@@ -4,7 +4,6 @@ import org.labkey.api.sequenceanalysis.pipeline.AbstractPipelineStepProvider;
 import org.labkey.api.sequenceanalysis.pipeline.PipelineContext;
 import org.labkey.api.singlecell.pipeline.SingleCellStep;
 
-import java.util.Arrays;
 import java.util.List;
 
 public class AppendMetadata extends AbstractRDiscvrStep

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/AppendSaturation.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/AppendSaturation.java
@@ -25,7 +25,6 @@ import org.labkey.singlecell.SingleCellSchema;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/AppendTcr.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/AppendTcr.java
@@ -6,7 +6,6 @@ import org.labkey.api.sequenceanalysis.pipeline.PipelineContext;
 import org.labkey.api.singlecell.pipeline.SeuratToolParameter;
 import org.labkey.api.singlecell.pipeline.SingleCellStep;
 
-import java.util.Arrays;
 import java.util.List;
 
 public class AppendTcr extends AbstractRDiscvrStep

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/CalculateGeneComponentScores.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/CalculateGeneComponentScores.java
@@ -7,7 +7,6 @@ import org.labkey.api.singlecell.pipeline.SeuratToolParameter;
 import org.labkey.api.singlecell.pipeline.SingleCellStep;
 import org.labkey.api.util.PageFlowUtil;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/CiteSeqPlots.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/CiteSeqPlots.java
@@ -6,7 +6,6 @@ import org.labkey.api.sequenceanalysis.pipeline.PipelineContext;
 import org.labkey.api.singlecell.pipeline.SeuratToolParameter;
 import org.labkey.api.singlecell.pipeline.SingleCellStep;
 
-import java.util.Arrays;
 import java.util.List;
 
 public class CiteSeqPlots extends AbstractCellMembraneStep

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/ClearCommands.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/ClearCommands.java
@@ -4,7 +4,6 @@ import org.labkey.api.sequenceanalysis.pipeline.AbstractPipelineStepProvider;
 import org.labkey.api.sequenceanalysis.pipeline.PipelineContext;
 import org.labkey.api.singlecell.pipeline.SingleCellStep;
 
-import java.util.Arrays;
 import java.util.List;
 
 public class ClearCommands extends AbstractCellMembraneStep

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/CustomUCell.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/CustomUCell.java
@@ -3,7 +3,6 @@ package org.labkey.singlecell.pipeline.singlecell;
 import org.json.JSONObject;
 import org.labkey.api.sequenceanalysis.pipeline.AbstractPipelineStepProvider;
 import org.labkey.api.sequenceanalysis.pipeline.PipelineContext;
-import org.labkey.api.sequenceanalysis.pipeline.ToolParameterDescriptor;
 import org.labkey.api.singlecell.pipeline.SeuratToolParameter;
 import org.labkey.api.singlecell.pipeline.SingleCellStep;
 

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/DietSeurat.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/DietSeurat.java
@@ -4,7 +4,6 @@ import org.labkey.api.sequenceanalysis.pipeline.AbstractPipelineStepProvider;
 import org.labkey.api.sequenceanalysis.pipeline.PipelineContext;
 import org.labkey.api.singlecell.pipeline.SingleCellStep;
 
-import java.util.Arrays;
 import java.util.List;
 
 public class DietSeurat extends AbstractCellMembraneStep

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/DimPlots.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/DimPlots.java
@@ -7,7 +7,6 @@ import org.labkey.api.singlecell.pipeline.SeuratToolParameter;
 import org.labkey.api.singlecell.pipeline.SingleCellStep;
 import org.labkey.api.util.PageFlowUtil;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/DoubletFinder.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/DoubletFinder.java
@@ -6,7 +6,6 @@ import org.labkey.api.sequenceanalysis.pipeline.PipelineContext;
 import org.labkey.api.singlecell.pipeline.SeuratToolParameter;
 import org.labkey.api.singlecell.pipeline.SingleCellStep;
 
-import java.util.Arrays;
 import java.util.List;
 
 public class DoubletFinder extends AbstractCellMembraneStep

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/DropAssays.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/DropAssays.java
@@ -6,7 +6,6 @@ import org.labkey.api.sequenceanalysis.pipeline.PipelineContext;
 import org.labkey.api.singlecell.pipeline.SeuratToolParameter;
 import org.labkey.api.singlecell.pipeline.SingleCellStep;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/DropCiteSeq.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/DropCiteSeq.java
@@ -4,7 +4,6 @@ import org.labkey.api.sequenceanalysis.pipeline.AbstractPipelineStepProvider;
 import org.labkey.api.sequenceanalysis.pipeline.PipelineContext;
 import org.labkey.api.singlecell.pipeline.SingleCellStep;
 
-import java.util.Arrays;
 import java.util.List;
 
 public class DropCiteSeq extends AbstractCellMembraneStep

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/FeaturePlots.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/FeaturePlots.java
@@ -7,7 +7,6 @@ import org.labkey.api.singlecell.pipeline.SeuratToolParameter;
 import org.labkey.api.singlecell.pipeline.SingleCellStep;
 import org.labkey.api.util.PageFlowUtil;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/FindClustersAndDimRedux.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/FindClustersAndDimRedux.java
@@ -6,7 +6,6 @@ import org.labkey.api.sequenceanalysis.pipeline.PipelineContext;
 import org.labkey.api.singlecell.pipeline.SeuratToolParameter;
 import org.labkey.api.singlecell.pipeline.SingleCellStep;
 
-import java.util.Arrays;
 import java.util.List;
 
 public class FindClustersAndDimRedux extends AbstractCellMembraneStep

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/PhenotypePlots.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/PhenotypePlots.java
@@ -5,7 +5,6 @@ import org.labkey.api.sequenceanalysis.pipeline.PipelineContext;
 import org.labkey.api.singlecell.pipeline.SingleCellStep;
 import org.labkey.api.util.PageFlowUtil;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/PlotAssayFeatures.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/PlotAssayFeatures.java
@@ -6,7 +6,6 @@ import org.labkey.api.sequenceanalysis.pipeline.PipelineContext;
 import org.labkey.api.singlecell.pipeline.SeuratToolParameter;
 import org.labkey.api.singlecell.pipeline.SingleCellStep;
 
-import java.util.Arrays;
 import java.util.Collections;
 
 public class PlotAssayFeatures extends AbstractCellMembraneStep

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/PredictScTour.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/PredictScTour.java
@@ -1,6 +1,5 @@
 package org.labkey.singlecell.pipeline.singlecell;
 
-import org.apache.commons.io.FileUtils;
 import org.json.JSONObject;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.pipeline.AbstractPipelineStepProvider;
@@ -10,12 +9,10 @@ import org.labkey.api.sequenceanalysis.pipeline.ToolParameterDescriptor;
 import org.labkey.api.singlecell.pipeline.SingleCellStep;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 public class PredictScTour extends AbstractRiraStep
 {

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/RunEscape.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/RunEscape.java
@@ -7,7 +7,6 @@ import org.labkey.api.singlecell.pipeline.SeuratToolParameter;
 import org.labkey.api.singlecell.pipeline.SingleCellStep;
 
 import java.util.Arrays;
-import java.util.Collections;
 
 public class RunEscape extends AbstractCellMembraneStep
 {

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/RunLDA.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/RunLDA.java
@@ -89,7 +89,7 @@ public class RunLDA extends AbstractCellMembraneStep
 
                 final String datasetId = line[0];
                 Set<SeuratObjectWrapper> wrappers = inputObjects.stream().filter(x -> datasetId.equals(x.getDatasetId())).collect(Collectors.toSet());
-                if (wrappers.size() == 0)
+                if (wrappers.isEmpty())
                 {
                     throw new PipelineJobException("Unable to find seurat object wrapper for: " + datasetId);
                 }

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/RunPCA.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/RunPCA.java
@@ -6,7 +6,6 @@ import org.labkey.api.sequenceanalysis.pipeline.PipelineContext;
 import org.labkey.api.singlecell.pipeline.SeuratToolParameter;
 import org.labkey.api.singlecell.pipeline.SingleCellStep;
 
-import java.util.Arrays;
 import java.util.List;
 
 public class RunPCA extends AbstractCellMembraneStep

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/RunPHATE.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/RunPHATE.java
@@ -5,7 +5,6 @@ import org.labkey.api.sequenceanalysis.pipeline.PipelineContext;
 import org.labkey.api.singlecell.pipeline.SeuratToolParameter;
 import org.labkey.api.singlecell.pipeline.SingleCellStep;
 
-import java.util.Arrays;
 import java.util.List;
 
 public class RunPHATE extends AbstractCellMembraneStep

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/RunSDA.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/RunSDA.java
@@ -9,7 +9,6 @@ import org.labkey.api.sequenceanalysis.SequenceOutputFile;
 import org.labkey.api.sequenceanalysis.pipeline.AbstractPipelineStepProvider;
 import org.labkey.api.sequenceanalysis.pipeline.PipelineContext;
 import org.labkey.api.sequenceanalysis.pipeline.SequenceOutputHandler;
-import org.labkey.api.sequenceanalysis.pipeline.ToolParameterDescriptor;
 import org.labkey.api.singlecell.pipeline.SeuratToolParameter;
 import org.labkey.api.singlecell.pipeline.SingleCellStep;
 
@@ -129,7 +128,7 @@ public class RunSDA extends AbstractCellMembraneStep
 
                 final String datasetId = line[0];
                 Set<SeuratObjectWrapper> wrappers = inputObjects.stream().filter(x -> datasetId.equals(x.getDatasetId())).collect(Collectors.toSet());
-                if (wrappers.size() == 0)
+                if (wrappers.isEmpty())
                 {
                     throw new PipelineJobException("Unable to find seurat object wrapper for: " + datasetId);
                 }

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/RunTricycle.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/RunTricycle.java
@@ -1,9 +1,7 @@
 package org.labkey.singlecell.pipeline.singlecell;
 
-import org.json.JSONObject;
 import org.labkey.api.sequenceanalysis.pipeline.AbstractPipelineStepProvider;
 import org.labkey.api.sequenceanalysis.pipeline.PipelineContext;
-import org.labkey.api.singlecell.pipeline.SeuratToolParameter;
 import org.labkey.api.singlecell.pipeline.SingleCellStep;
 
 import java.util.Arrays;

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/RunVision.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/RunVision.java
@@ -13,7 +13,6 @@ import org.labkey.api.singlecell.pipeline.SingleCellStep;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -84,7 +83,7 @@ public class RunVision extends AbstractCellMembraneStep
 
                 final String datasetId = line[0];
                 Set<SeuratObjectWrapper> wrappers = inputObjects.stream().filter(x -> datasetId.equals(x.getDatasetId())).collect(Collectors.toSet());
-                if (wrappers.size() == 0)
+                if (wrappers.isEmpty())
                 {
                     throw new PipelineJobException("Unable to find seurat object wrapper for: " + datasetId);
                 }

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/SubsetSeurat.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/SubsetSeurat.java
@@ -9,7 +9,6 @@ import org.labkey.api.sequenceanalysis.pipeline.ToolParameterDescriptor;
 import org.labkey.api.singlecell.pipeline.SingleCellStep;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/TcrFilter.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/TcrFilter.java
@@ -7,7 +7,6 @@ import org.labkey.api.singlecell.pipeline.SeuratToolParameter;
 import org.labkey.api.singlecell.pipeline.SingleCellStep;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 public class TcrFilter extends AbstractCellMembraneStep

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/UpdateSeuratPrototype.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/UpdateSeuratPrototype.java
@@ -25,7 +25,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
 
 import static org.labkey.singlecell.analysis.AbstractSingleCellHandler.SEURAT_PROTOTYPE;
 

--- a/singlecell/src/org/labkey/singlecell/run/CellRangerFeatureBarcodeHandler.java
+++ b/singlecell/src/org/labkey/singlecell/run/CellRangerFeatureBarcodeHandler.java
@@ -22,7 +22,6 @@ import org.labkey.api.pipeline.RecordedAction;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.reader.Readers;
-import org.labkey.api.sequenceanalysis.SequenceAnalysisService;
 import org.labkey.api.sequenceanalysis.SequenceOutputFile;
 import org.labkey.api.sequenceanalysis.model.Readset;
 import org.labkey.api.sequenceanalysis.pipeline.AbstractParameterizedOutputHandler;
@@ -313,7 +312,7 @@ public class CellRangerFeatureBarcodeHandler extends AbstractParameterizedOutput
                 if (ctx.getParams().optBoolean("useGEX", false))
                 {
                     description = description + "\n" + "HTO and GEX Counts";
-                };
+                }
                 output.addSequenceOutput(outputHtmlRename, rs.getName() + " 10x " + rs.getApplication() + " Summary", "10x Run Summary", rs.getRowId(), null, null, description);
 
                 File rawCounts = new File(outsdir, "raw_feature_bc_matrix/matrix.mtx.gz");

--- a/singlecell/src/org/labkey/singlecell/run/CellRangerVDJWrapper.java
+++ b/singlecell/src/org/labkey/singlecell/run/CellRangerVDJWrapper.java
@@ -3,7 +3,6 @@ package org.labkey.singlecell.run;
 import au.com.bytecode.opencsv.CSVReader;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.stream.IntStreams;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;

--- a/singlecell/src/org/labkey/singlecell/run/RepeatNimbleReportHandler.java
+++ b/singlecell/src/org/labkey/singlecell/run/RepeatNimbleReportHandler.java
@@ -196,7 +196,7 @@ public class RepeatNimbleReportHandler extends AbstractParameterizedOutputHandle
                     {
                         throw new PipelineJobException(e);
                     }
-;                }
+                }
                 else
                 {
                     ctx.getLogger().debug("Plot file output exists, will not re-create");

--- a/singlecell/test/src/org/labkey/test/tests/singlecell/SingleCellTest.java
+++ b/singlecell/test/src/org/labkey/test/tests/singlecell/SingleCellTest.java
@@ -27,8 +27,6 @@ import org.labkey.test.categories.InDevelopment;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.*;
-
 @Category({InDevelopment.class})
 public class SingleCellTest extends BaseWebDriverTest
 {
@@ -41,7 +39,7 @@ public class SingleCellTest extends BaseWebDriverTest
     @BeforeClass
     public static void setupProject()
     {
-        SingleCellTest init = (SingleCellTest)getCurrentTest();
+        SingleCellTest init = getCurrentTest();
 
         init.doSetup();
     }


### PR DESCRIPTION
#### Rationale
We can cleanup tens of thousands of warnings across our codebase with IntelliJ's autorefactors. In some cases, this adopts newer, leaner syntax. In others, it simply removes code that's not serving any purpose.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6742

#### Changes
- Auto-refactors
  - Eliminate redundant toString()
  - Eliminate redundant cast
  - Empty JavaDoc annotations
  - Member variable can be final
  - length() and size() -> isEmpty()
  - Add missing @Override
  - Class can be static
  - Remove unused imports
  - toArray() passed array length
  - Remove unnecessary semicolon
  - Explicit type syntax can be replaced by <>
  - Redundant access modifiers
  - Remove redundant initializer
  - "".equals() -> isEmpty()
  - StringBuilder can be replaced by String
  - Fix misordered arguments to assertEquals()
  - StringUtils.defaultString() - Objects.toString()
  - Cast can be replaced with pattern variable
  - Collapse identical catch blocks
  - Type may be primitive
- Manual fixups
  - Delete unused GWT code
  - Improve generics
  - new UnexpectedException() -> UnexpectedException.wrap()


