### PR TITLE
Pull 'cisd:jhdf5' dependency from Artifactory

### DIFF
--- a/SequenceAnalysis/build.gradle
+++ b/SequenceAnalysis/build.gradle
@@ -9,15 +9,15 @@ import org.labkey.gradle.util.ExternalDependency
 
 import java.util.regex.Matcher
 
-repositories {
-    mavenCentral()
-    maven {
-        url "https://maven.scijava.org/content/groups/public/"
-        content {
-            includeGroup "cisd" //jhdf5
-        }
-    }
-}
+//repositories {
+//    mavenCentral()
+//    maven {
+//        url "https://maven.scijava.org/content/groups/public/"
+//        content {
+//            includeGroup "cisd" //jhdf5
+//        }
+//    }
+//}
 
 configurations.all {
     resolutionStrategy {
@@ -93,18 +93,18 @@ dependencies {
             )
     )
 
-    BuildUtils.addExternalDependency(
-            project,
-            new ExternalDependency(
-                    'cisd:jhdf5:19.04.1',
-                    'JHDF5',
-                    'JHDF5',
-                    'https://unlimited.ethz.ch/display/JHDF/',
-                    ExternalDependency.BSD_LICENSE_NAME,
-                    ExternalDependency.BSD_LICENSE_URL,
-                    'JHDF5 is a Java binding for HDF5. Used by FastQC'
-            )
-    )
+//    BuildUtils.addExternalDependency(
+//            project,
+//            new ExternalDependency(
+//                    'cisd:jhdf5:19.04.1',
+//                    'JHDF5',
+//                    'JHDF5',
+//                    'https://unlimited.ethz.ch/display/JHDF/',
+//                    ExternalDependency.BSD_LICENSE_NAME,
+//                    ExternalDependency.BSD_LICENSE_URL,
+//                    'JHDF5 is a Java binding for HDF5. Used by FastQC'
+//            )
+//    )
 
     BuildUtils.addExternalDependency(
             project,

--- a/SequenceAnalysis/build.gradle
+++ b/SequenceAnalysis/build.gradle
@@ -93,18 +93,18 @@ dependencies {
             )
     )
 
-//    BuildUtils.addExternalDependency(
-//            project,
-//            new ExternalDependency(
-//                    'cisd:jhdf5:19.04.1',
-//                    'JHDF5',
-//                    'JHDF5',
-//                    'https://unlimited.ethz.ch/display/JHDF/',
-//                    ExternalDependency.BSD_LICENSE_NAME,
-//                    ExternalDependency.BSD_LICENSE_URL,
-//                    'JHDF5 is a Java binding for HDF5. Used by FastQC'
-//            )
-//    )
+    BuildUtils.addExternalDependency(
+            project,
+            new ExternalDependency(
+                    'cisd:jhdf5:19.04.1',
+                    'JHDF5',
+                    'JHDF5',
+                    'https://unlimited.ethz.ch/display/JHDF/',
+                    ExternalDependency.BSD_LICENSE_NAME,
+                    ExternalDependency.BSD_LICENSE_URL,
+                    'JHDF5 is a Java binding for HDF5. Used by FastQC'
+            )
+    )
 
     BuildUtils.addExternalDependency(
             project,

--- a/jbrowse/build.gradle
+++ b/jbrowse/build.gradle
@@ -1,15 +1,15 @@
 import org.labkey.gradle.util.BuildUtils;
 
-repositories {
-	mavenCentral()
-	maven {
-		url "https://maven.scijava.org/content/repositories/public/"
-		content {
-			// Transitive dependency from SequenceAnalysis
-			includeGroup "cisd" //jhdf5
-		}
-	}
-}
+//repositories {
+//	mavenCentral()
+//	maven {
+//		url "https://maven.scijava.org/content/repositories/public/"
+//		content {
+//			// Transitive dependency from SequenceAnalysis
+//			includeGroup "cisd" //jhdf5
+//		}
+//	}
+//}
 
 dependencies {
     apiImplementation "com.github.samtools:htsjdk:${htsjdkVersion}"


### PR DESCRIPTION
#### Rationale
https://forum.image.sc/t/unplanned-server-outage-for-maven-scijava-org/113683

[maven.scijava.org](https://maven.scijava.org) will be offline for a couple of days. ~We need to remove the `cisd:jhdf5` dependency that comes from there in order for TeamCity to run some critical builds. Fortunately, removing this dependency won't cause any compile-time errors. SequenceAnalysis `FastqcRunner` will be broken but not any more broken than if we can't build.~

Change of plans, we've uploaded `cisd:jhdf5` to Artifactory. Removing the scijava repository declaration will cause the build to check Artifactory instead.

#### Related Pull Requests
* https://github.com/LabKey/DiscvrLabKeyModules/pull/356

#### Changes
* Pull 'cisd:jhdf5' dependency from Artifactory