### PR TITLE
Pull 'cisd:jhdf5' dependency from Artifactory

### DIFF
--- a/SequenceAnalysis/build.gradle
+++ b/SequenceAnalysis/build.gradle
@@ -91,18 +91,18 @@ dependencies {
             )
     )
 
-//    BuildUtils.addExternalDependency(
-//            project,
-//            new ExternalDependency(
-//                    'cisd:jhdf5:19.04.1',
-//                    'JHDF5',
-//                    'JHDF5',
-//                    'https://unlimited.ethz.ch/display/JHDF/',
-//                    ExternalDependency.BSD_LICENSE_NAME,
-//                    ExternalDependency.BSD_LICENSE_URL,
-//                    'JHDF5 is a Java binding for HDF5. Used by FastQC'
-//            )
-//    )
+    BuildUtils.addExternalDependency(
+            project,
+            new ExternalDependency(
+                    'cisd:jhdf5:19.04.1',
+                    'JHDF5',
+                    'JHDF5',
+                    'https://unlimited.ethz.ch/display/JHDF/',
+                    ExternalDependency.BSD_LICENSE_NAME,
+                    ExternalDependency.BSD_LICENSE_URL,
+                    'JHDF5 is a Java binding for HDF5. Used by FastQC'
+            )
+    )
 
     BuildUtils.addExternalDependency(
             project,


### PR DESCRIPTION
#### Rationale
https://forum.image.sc/t/unplanned-server-outage-for-maven-scijava-org/113683

Change of plans, we've uploaded `cisd:jhdf5` to Artifactory. Removing the scijava repository declaration will cause the build to check Artifactory instead.

#### Related Pull Requests
* https://github.com/LabKey/DiscvrLabKeyModules/pull/356

#### Changes
* Pull 'cisd:jhdf5' dependency from Artifactory