### PR TITLE
Relocate methods related to file name uniqueness to `FileUtil`

### DIFF
--- a/QueryExtensions/src/org/labkey/queryextensions/QueryExtensionsModule.java
+++ b/QueryExtensions/src/org/labkey/queryextensions/QueryExtensionsModule.java
@@ -40,7 +40,7 @@ public class QueryExtensionsModule extends DefaultModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 23.000;
+        return 25.000;
     }
 
     @Override

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisController.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisController.java
@@ -2151,7 +2151,7 @@ public class SequenceAnalysisController extends SpringActionController
 
             File targetDirectory = root.getRootPath();
 
-            return AssayFileWriter.findUniqueFileName(filename, targetDirectory);
+            return FileUtil.findUniqueFileName(filename, targetDirectory);
         }
 
         @Override
@@ -2449,7 +2449,7 @@ public class SequenceAnalysisController extends SpringActionController
             try
             {
                 FileLike targetDirectory = AssayFileWriter.ensureUploadDirectory(getContainer(), "sequenceOutputs");
-                return AssayFileWriter.findUniqueFileName(filename, targetDirectory).toNioPathForWrite().toFile();
+                return FileUtil.findUniqueFileName(filename, targetDirectory).toNioPathForWrite().toFile();
             }
             catch (ExperimentException e)
             {
@@ -2582,7 +2582,7 @@ public class SequenceAnalysisController extends SpringActionController
             try
             {
                 FileLike targetDirectory = AssayFileWriter.ensureUploadDirectory(getContainer());
-                return AssayFileWriter.findUniqueFileName(filename, targetDirectory).toNioPathForWrite().toFile();
+                return FileUtil.findUniqueFileName(filename, targetDirectory).toNioPathForWrite().toFile();
             }
             catch (ExperimentException e)
             {
@@ -2747,7 +2747,7 @@ public class SequenceAnalysisController extends SpringActionController
             try
             {
                 FileLike targetDirectory = AssayFileWriter.ensureUploadDirectory(getContainer());
-                return AssayFileWriter.findUniqueFileName(filename, targetDirectory).toNioPathForWrite().toFile();
+                return FileUtil.findUniqueFileName(filename, targetDirectory).toNioPathForWrite().toFile();
             }
             catch (ExperimentException e)
             {
@@ -4089,7 +4089,7 @@ public class SequenceAnalysisController extends SpringActionController
 
                 for (File file : toCreate.keySet())
                 {
-                    FileLike target = AssayFileWriter.findUniqueFileName(file.getName(), targetDirectory);
+                    FileLike target = FileUtil.findUniqueFileName(file.getName(), targetDirectory);
                     FileUtils.moveFile(file, target.toNioPathForWrite().toFile());
 
                     ExpData data = ExperimentService.get().createData(getContainer(), new DataType("Sequence Output"));

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisManager.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisManager.java
@@ -24,7 +24,6 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
-import org.labkey.api.assay.AssayFileWriter;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
@@ -67,6 +66,7 @@ import org.labkey.api.sequenceanalysis.GenomeTrigger;
 import org.labkey.api.sequenceanalysis.RefNtSequenceModel;
 import org.labkey.api.sequenceanalysis.SequenceOutputFile;
 import org.labkey.api.sequenceanalysis.pipeline.SequenceOutputHandler;
+import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.Job;
 import org.labkey.api.util.JobRunner;
 import org.labkey.api.util.PageFlowUtil;
@@ -827,7 +827,7 @@ public class SequenceAnalysisManager
 
         //create file
         String expectedName = "chain-" + genomeId1 + "to" + genomeId2 + ".chain";
-        File outputFile = AssayFileWriter.findUniqueFileName(expectedName, targetDir);
+        File outputFile = FileUtil.findUniqueFileName(expectedName, targetDir);
 
         FileUtils.moveFile(file, outputFile);
         ExpData chainFile = ExperimentService.get().createData(c, new DataType("Sequence Track"));

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ImportFastaSequencesPipelineJob.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ImportFastaSequencesPipelineJob.java
@@ -69,7 +69,7 @@ public class ImportFastaSequencesPipelineJob extends PipelineJob
 
         AssayFileWriter writer = new AssayFileWriter();
         String folderName = "SequenceImport_" + FileUtil.getTimestamp();
-        webserverOutDir = AssayFileWriter.findUniqueFileName(folderName, webserverOutDir);
+        webserverOutDir = FileUtil.findUniqueFileName(folderName, webserverOutDir);
         if (!webserverOutDir.exists())
         {
             webserverOutDir.mkdirs();

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ImportGenomeTrackTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ImportGenomeTrackTask.java
@@ -33,7 +33,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.jetbrains.annotations.Nullable;
-import org.labkey.api.assay.AssayFileWriter;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
@@ -61,6 +60,7 @@ import org.labkey.api.sequenceanalysis.pipeline.ReferenceGenome;
 import org.labkey.api.sequenceanalysis.pipeline.ReferenceGenomeManager;
 import org.labkey.api.sequenceanalysis.pipeline.SequencePipelineService;
 import org.labkey.api.util.FileType;
+import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.Job;
 import org.labkey.api.util.JobRunner;
 import org.labkey.api.util.PageFlowUtil;
@@ -354,7 +354,7 @@ public class ImportGenomeTrackTask extends PipelineJob.Task<ImportGenomeTrackTas
     }
     private File getOutputFile(File file, File tracksDir)
     {
-        return AssayFileWriter.findUniqueFileName(file.getName().replaceAll(" ", "_"), tracksDir);
+        return FileUtil.findUniqueFileName(file.getName().replaceAll(" ", "_"), tracksDir);
     }
 
     private Map<String, Pair<String, Integer>> getNameTranslationMap(List<RefNtSequenceModel> refNtSequenceModels) throws PipelineJobException

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceJob.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceJob.java
@@ -10,7 +10,6 @@ import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
-import org.labkey.api.assay.AssayFileWriter;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.exp.api.DataType;
@@ -164,7 +163,7 @@ public class SequenceJob extends PipelineJob implements FileAnalysisJobSupport, 
 
     private Path _getLogFile()
     {
-        var file = AssayFileWriter.findUniqueFileName((FileUtil.makeLegalName(_jobName) + ".log"), getDataDirectoryFileObject());
+        var file = FileUtil.findUniqueFileName((FileUtil.makeLegalName(_jobName) + ".log"), getDataDirectoryFileObject());
         return file.toNioPathForWrite();
     }
 
@@ -228,7 +227,7 @@ public class SequenceJob extends PipelineJob implements FileAnalysisJobSupport, 
         }
 
         String folderName = FileUtil.makeLegalName(StringUtils.capitalize(_folderPrefix) + "_" + FileUtil.getTimestamp());
-        webserverOutDir = AssayFileWriter.findUniqueFileName(folderName, webserverOutDir);
+        webserverOutDir = FileUtil.findUniqueFileName(folderName, webserverOutDir);
         if (!webserverOutDir.exists())
         {
             webserverOutDir.mkdir();

--- a/blast/src/org/labkey/blast/BLASTController.java
+++ b/blast/src/org/labkey/blast/BLASTController.java
@@ -50,6 +50,7 @@ import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.util.ExceptionUtil;
+import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringUtilsLabKey;
@@ -217,7 +218,7 @@ public class BLASTController extends SpringActionController
             try
             {
                 FileLike targetDirectory = AssayFileWriter.ensureUploadDirectory(getContainer());
-                return AssayFileWriter.findUniqueFileName(filename, targetDirectory).toNioPathForWrite().toFile();
+                return FileUtil.findUniqueFileName(filename, targetDirectory).toNioPathForWrite().toFile();
             }
             catch (ExperimentException e)
             {
@@ -265,7 +266,7 @@ public class BLASTController extends SpringActionController
                     try
                     {
                         FileLike targetDirectory = AssayFileWriter.ensureUploadDirectory(getContainer());
-                        FileLike input = AssayFileWriter.findUniqueFileName("blast", targetDirectory);
+                        FileLike input = FileUtil.findUniqueFileName("blast", targetDirectory);
                         input.createFile();
                         try (PrintWriter fw = PrintWriters.getPrintWriter(input.openOutputStream()))
                         {

--- a/jbrowse/src/org/labkey/jbrowse/pipeline/JBrowseLucenePipelineJob.java
+++ b/jbrowse/src/org/labkey/jbrowse/pipeline/JBrowseLucenePipelineJob.java
@@ -3,7 +3,6 @@ package org.labkey.jbrowse.pipeline;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.logging.log4j.Logger;
-import org.labkey.api.assay.AssayFileWriter;
 import org.labkey.api.data.Container;
 import org.labkey.api.files.FileUrls;
 import org.labkey.api.module.Module;
@@ -59,7 +58,7 @@ public class JBrowseLucenePipelineJob extends PipelineJob
         _infoFields = infoFields;
         _allowLenientLuceneProcessing = allowLenientLuceneProcessing;
 
-        setLogFile(AssayFileWriter.findUniqueFileName("jbrowse-lucene" + new GUID() + ".log", JBrowseManager.get().getBaseDir(c, true)));
+        setLogFile(FileUtil.findUniqueFileName("jbrowse-lucene" + new GUID() + ".log", JBrowseManager.get().getBaseDir(c, true)));
     }
 
     public static class JBrowseLucenePipelineProvider extends PipelineProvider

--- a/jbrowse/src/org/labkey/jbrowse/pipeline/JBrowseSessionPipelineJob.java
+++ b/jbrowse/src/org/labkey/jbrowse/pipeline/JBrowseSessionPipelineJob.java
@@ -1,7 +1,6 @@
 package org.labkey.jbrowse.pipeline;
 
 import org.jetbrains.annotations.Nullable;
-import org.labkey.api.assay.AssayFileWriter;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.SimpleFilter;
@@ -15,6 +14,7 @@ import org.labkey.api.pipeline.TaskPipeline;
 import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.User;
+import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
@@ -101,7 +101,7 @@ public class JBrowseSessionPipelineJob extends PipelineJob
         _sourceContainerId = databaseGuid == null ? getContainerId() : getSourceContainerId(databaseGuid);
         _mode = mode;
 
-        setLogFile(AssayFileWriter.findUniqueFileName("jbrowse-" + new GUID() + ".log", JBrowseManager.get().getBaseDir(c, true)));
+        setLogFile(FileUtil.findUniqueFileName("jbrowse-" + new GUID() + ".log", JBrowseManager.get().getBaseDir(c, true)));
     }
 
     private JBrowseSessionPipelineJob(Container c, User user, PipeRoot pipeRoot, String name, String description, Integer libraryId, List<Integer> trackIds, List<Integer> outputFileIds, @Nullable String existingDatabaseGuid, boolean isTemporarySession)
@@ -118,7 +118,7 @@ public class JBrowseSessionPipelineJob extends PipelineJob
         _sourceContainerId = existingDatabaseGuid == null ? getContainerId() : getSourceContainerId(existingDatabaseGuid);
         _isTemporarySession = isTemporarySession;
 
-        setLogFile(AssayFileWriter.findUniqueFileName("jbrowse-" + _databaseGuid + ".log", JBrowseManager.get().getBaseDir(c, true)));
+        setLogFile(FileUtil.findUniqueFileName("jbrowse-" + _databaseGuid + ".log", JBrowseManager.get().getBaseDir(c, true)));
     }
 
     private String getSourceContainerId(String databaseGuid)


### PR DESCRIPTION
#### Rationale
Since there's nothing specific about assays in the `findUniqueFileName` method (and relatives), they are better located in the `FileUtil` class than `AssayFileWriter`.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6869

#### Changes
* Adjust location for `findUniqueFileName` method.
