### PR TITLE
Skip inserting active modules if creating empty schemas

### DIFF
--- a/OpenLdapSync/src/org/labkey/openldapsync/OpenLdapSyncModule.java
+++ b/OpenLdapSync/src/org/labkey/openldapsync/OpenLdapSyncModule.java
@@ -23,6 +23,7 @@ import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleContext;
+import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.module.SpringModule;
 import org.labkey.api.query.DefaultSchema;
 import org.labkey.api.query.DetailsURL;
@@ -100,7 +101,8 @@ public class OpenLdapSyncModule extends SpringModule
         {
             modules = new HashSet<>(modules);
             modules.add(this);
-            ContainerManager.getSharedContainer().setActiveModules(modules);
+            if (ModuleLoader.getInstance().shouldInsertData())
+                ContainerManager.getSharedContainer().setActiveModules(modules);
         }
     }
 

--- a/SequenceAnalysis/resources/schemas/dbscripts/postgresql/SequenceAnalysis-0.00-11.20.sql
+++ b/SequenceAnalysis/resources/schemas/dbscripts/postgresql/SequenceAnalysis-0.00-11.20.sql
@@ -129,6 +129,7 @@ WITH (OIDS=FALSE);
 -- ----------------------------
 -- Records of barcodes
 -- ----------------------------
+-- @SkipOnEmptySchemasBegin
 INSERT INTO sequenceanalysis.barcodes (tag_name, sequence, group_name) VALUES ('MID01', 'ACGAGTGCGT', 'GSMIDs');
 INSERT INTO sequenceanalysis.barcodes (tag_name, sequence, group_name) VALUES ('MID02', 'ACGCTCGACA', 'GSMIDs');
 INSERT INTO sequenceanalysis.barcodes (tag_name, sequence, group_name) VALUES ('MID03', 'AGACGCACTC', 'GSMIDs');
@@ -282,7 +283,7 @@ INSERT INTO sequenceanalysis.barcodes (tag_name, sequence, group_name) VALUES ('
 INSERT INTO sequenceanalysis.barcodes (tag_name, sequence, group_name) VALUES ('MID151', 'TGCTAGTCAG', 'GSMIDs');
 INSERT INTO sequenceanalysis.barcodes (tag_name, sequence, group_name) VALUES ('MID152', 'TGTATCACAG', 'GSMIDs');
 INSERT INTO sequenceanalysis.barcodes (tag_name, sequence, group_name) VALUES ('MID153', 'TGTGCGCGTG', 'GSMIDs');
-
+-- @SkipOnEmptySchemasEnd
 
 -- ----------------------------
 -- Table structure for sequenceAnalysis.ref_nt_sequences
@@ -1061,6 +1062,7 @@ WITH (OIDS=FALSE)
 -- ----------------------------
 -- Records of sequenceAnalysis.dna_adapters
 -- ----------------------------
+-- @SkipOnEmptySchemasBegin
 INSERT INTO sequenceanalysis.dna_adapters (name, group_name, sequence) VALUES
 ('Roche-454 FLX Amplicon A', 'Roche-454 FLX Amplicon', 'GCCTCCCTCGCGCCATCAG'),
 ('Roche-454 FLX Amplicon B', 'Roche-454 FLX Amplicon', 'GCCTTGCCAGCCCGCTCAG'),
@@ -1070,7 +1072,7 @@ INSERT INTO sequenceanalysis.dna_adapters (name, group_name, sequence) VALUES
 ('Roche-454 Titanium Library A', 'Roche-454 Titanium Library', 'CCATCTCATCCCTGCGTGTCTCCGACTCAG'),
 ('Roche-454 Titanium Library B', 'Roche-454 Titanium Library', 'CCTATCCCCTGTGTGCCTTGGCAGTCTCAG'),
 ('Nextera Transposon Adapter A', 'Nextera Adapters', 'AGATGTGTATAAGAGACAG');
-
+-- @SkipOnEmptySchemasEnd
 
 
 -- ----------------------------
@@ -1089,6 +1091,7 @@ WITH (OIDS=FALSE)
 -- ----------------------------
 -- Records of sequenceanalysis.dna_loci
 -- ----------------------------
+-- @SkipOnEmptySchemasBegin
 INSERT INTO sequenceanalysis.dna_loci
 VALUES
 ('MHC-A', '-a'),
@@ -1111,7 +1114,7 @@ VALUES
 ('HLA-A', 'hla-a'),
 ('HLA-B', 'hla-b'),
 ('HLA-C', 'hla-c');
-
+-- @SkipOnEmptySchemasEnd
 
 
 
@@ -1130,7 +1133,9 @@ WITH (OIDS=FALSE)
 -- ----------------------------
 -- Records of sequenceAnalysis.ref_nt_category
 -- ----------------------------
+-- @SkipOnEmptySchemasBegin
 INSERT INTO sequenceAnalysis.ref_nt_category (category) VALUES ('Virus'), ('DNA');
+-- @SkipOnEmptySchemasEnd
 
 -- ----------------------------
 -- Table structure for sequenceanalysis.dna_region
@@ -1146,7 +1151,9 @@ WITH (OIDS=FALSE);
 -- ----------------------------
 -- Records of sequenceAnalysis.dna_region
 -- ----------------------------
+-- @SkipOnEmptySchemasBegin
 INSERT INTO sequenceAnalysis.dna_region (region) VALUES ('KIR'), ('MHC');
+-- @SkipOnEmptySchemasEnd
 
 -- ----------------------------
 -- Table structure for sequenceanalysis.geographic_origins
@@ -1657,12 +1664,13 @@ CREATE TABLE sequenceanalysis.analysis_types (
 WITH (OIDS=FALSE)
 ;
 
+-- @SkipOnEmptySchemasBegin
 INSERT INTO sequenceanalysis.analysis_types
 (type) VALUES
 ('Virus'),
 ('SBT')
 ;
-
+-- @SkipOnEmptySchemasEnd
 
 
 --foreign keys not necessary.

--- a/SequenceAnalysis/resources/schemas/dbscripts/postgresql/SequenceAnalysis-11.20-11.30.sql
+++ b/SequenceAnalysis/resources/schemas/dbscripts/postgresql/SequenceAnalysis-11.20-11.30.sql
@@ -51,6 +51,7 @@ WITH (OIDS=FALSE)
 -- ----------------------------
 -- Records of sequenceAnalysis.sequence_platforms
 -- ----------------------------
+-- @SkipOnEmptySchemasBegin
 INSERT INTO sequenceanalysis.sequence_platforms
 (platform,aliases)
 VALUES
@@ -62,11 +63,14 @@ VALUES
 ('ION_TORRENT', 'IONTORRENT'),
 ('SANGER', null)
 ;
+-- @SkipOnEmptySchemasEnd
 
 update sequenceAnalysis.sequence_reads set chemistry = 'LS454' where chemistry = 'Pyrosequencing';
 
 delete from sequenceAnalysis.site_module_properties where prop_name = 'contactEmail';
+-- @SkipOnEmptySchemasBegin
 insert into sequenceAnalysis.site_module_properties (prop_name, stringValue) VALUES ('contactEmail', 'bbimber@labkey.com');
+-- @SkipOnEmptySchemasEnd
 
 DROP TABLE IF EXISTS sequenceAnalysis.sequence_readsets;
 CREATE TABLE sequenceAnalysis.sequence_readsets (

--- a/SequenceAnalysis/resources/schemas/dbscripts/postgresql/SequenceAnalysis-12.10-12.20.sql
+++ b/SequenceAnalysis/resources/schemas/dbscripts/postgresql/SequenceAnalysis-12.10-12.20.sql
@@ -74,12 +74,14 @@ CREATE TABLE sequenceanalysis.quality_metrics_types (
   CONSTRAINT PK_quality_metrics_types PRIMARY KEY (type)
 );
 
+-- @SkipOnEmptySchemasBegin
 INSERT INTO sequenceanalysis.quality_metrics_types (type) VALUES ('Total Sequences');
 INSERT INTO sequenceanalysis.quality_metrics_types (type) VALUES ('Filtered Sequences');
 INSERT INTO sequenceanalysis.quality_metrics_types (type) VALUES ('Avg Sequence Length');
 INSERT INTO sequenceanalysis.quality_metrics_types (type) VALUES ('Min Sequence Length');
 INSERT INTO sequenceanalysis.quality_metrics_types (type) VALUES ('Max Sequence Length');
 INSERT INTO sequenceanalysis.quality_metrics_types (type) VALUES ('%GC');
+-- @SkipOnEmptySchemasEnd
 
 ALTER TABLE sequenceanalysis.sequence_readsets DROP COLUMN machine_run_id;
 ALTER TABLE sequenceanalysis.sequence_readsets ADD COLUMN instrument_run_id integer;
@@ -187,7 +189,9 @@ UPDATE sequenceanalysis.ref_nt_sequences set genbank = 'SIVmac239' WHERE name = 
 UPDATE sequenceanalysis.ref_nt_sequences set genbank = 'SIVmac251' WHERE name = 'M19499';
 UPDATE sequenceanalysis.ref_nt_sequences set genbank = 'SIVsmE543' WHERE name = 'U72748.2';
 
+-- @SkipOnEmptySchemasBegin
 INSERT INTO sequenceanalysis.sequence_platforms (platform) VALUES ('MIXED');
+-- @SkipOnEmptySchemasEnd
 
 --delete duplicate epitopes accidentally entered
 update sequenceanalysis.ref_aa_features set comment = null where comment = '';

--- a/SequenceAnalysis/resources/schemas/dbscripts/postgresql/SequenceAnalysis-12.12-12.13.sql
+++ b/SequenceAnalysis/resources/schemas/dbscripts/postgresql/SequenceAnalysis-12.12-12.13.sql
@@ -38,7 +38,9 @@ UPDATE sequenceanalysis.ref_nt_sequences set genbank = 'SIVmac239' WHERE name = 
 UPDATE sequenceanalysis.ref_nt_sequences set genbank = 'SIVmac251' WHERE name = 'M19499';
 UPDATE sequenceanalysis.ref_nt_sequences set genbank = 'SIVsmE543' WHERE name = 'U72748.2';
 
+-- @SkipOnEmptySchemasBegin
 INSERT INTO sequenceanalysis.sequence_platforms (platform) VALUES ('MIXED');
+-- @SkipOnEmptySchemasEnd
 
 --delete duplicate epitopes accidentally entered
 update sequenceanalysis.ref_aa_features set comment = null where comment = '';

--- a/SequenceAnalysis/resources/schemas/dbscripts/postgresql/SequenceAnalysis-12.20-12.21.sql
+++ b/SequenceAnalysis/resources/schemas/dbscripts/postgresql/SequenceAnalysis-12.20-12.21.sql
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+-- @SkipOnEmptySchemasBegin
 INSERT INTO sequenceanalysis.barcodes (tag_name, sequence, group_name) VALUES ('N701', 'TCGCCTTA', 'Illumina');
 INSERT INTO sequenceanalysis.barcodes (tag_name, sequence, group_name) VALUES ('N702', 'CTAGTACG', 'Illumina');
 INSERT INTO sequenceanalysis.barcodes (tag_name, sequence, group_name) VALUES ('N703', 'TTCTGCCT', 'Illumina');
@@ -420,3 +421,4 @@ INSERT into sequenceanalysis.barcodes (tag_name, sequence, group_name) VALUES ('
 INSERT into sequenceanalysis.barcodes (tag_name, sequence, group_name) VALUES ('FLD0382', 'AAGGTATGAG', 'Fluidigm');
 INSERT into sequenceanalysis.barcodes (tag_name, sequence, group_name) VALUES ('FLD0383', 'ATGGAGCACT', 'Fluidigm');
 INSERT into sequenceanalysis.barcodes (tag_name, sequence, group_name) VALUES ('FLD0384', 'ACGGTGCTAG', 'Fluidigm');
+-- @SkipOnEmptySchemasEnd

--- a/SequenceAnalysis/resources/schemas/dbscripts/postgresql/SequenceAnalysis-12.25-12.26.sql
+++ b/SequenceAnalysis/resources/schemas/dbscripts/postgresql/SequenceAnalysis-12.25-12.26.sql
@@ -17,7 +17,9 @@ ALTER TABLE sequenceanalysis.quality_metrics add column analysis_id integer;
 
 ALTER TABLE sequenceanalysis.aa_snps_by_codon add column ref_nt_positions varchar(200);
 
+-- @SkipOnEmptySchemasBegin
 INSERT into sequenceanalysis.quality_metrics_types (type) VALUES ('%Reads Aligned In Pairs');
 INSERT into sequenceanalysis.quality_metrics_types (type) VALUES ('Total Sequences Passed Filter');
 INSERT into sequenceanalysis.quality_metrics_types (type) VALUES ('Reads Aligned');
 INSERT into sequenceanalysis.quality_metrics_types (type) VALUES ('%Reads Aligned');
+-- @SkipOnEmptySchemasEnd

--- a/SequenceAnalysis/resources/schemas/dbscripts/postgresql/SequenceAnalysis-12.26-12.261.sql
+++ b/SequenceAnalysis/resources/schemas/dbscripts/postgresql/SequenceAnalysis-12.26-12.261.sql
@@ -2,9 +2,11 @@
 -- insert into sequenceanalysis.aligners (haplotype,displayhaplotype,description,jsonconfig) values
 -- ('mosaik', 'Mosaik', 'Mosaik is suitable for longer reads and has the option to retain multiple hits per read.  The only downside is that it can be slower.  When this pipeline was first written, this aligner was preferred for sequence-based genotyping and similar applications which require retaining multiple hits.  It supports paired end reads.  The aligner is still good; however, Lastz also seems to perform well for SBT.', '[{"xtype":"hidden","name":"pairedEnd","value":"true"},{"name":"mosaik.output_multiple","fieldLabel":"Retain All Hits","xtype":"checkbox","renderData":{"helpPopup":"If selected, all hits above thresholds will be reported.  If not, only a single hit will be retained."},"checked":true},{"name":"mosaik.max_mismatch_pct","fieldLabel":"Max Mismatch Pct","renderData":{"helpPopup":"The maximum percent of bases allowed to mismatch per alignment.  Note: Ns are counted as mismatches"},"value":0.02,"minValue":0,"maxValue":1},{"name":"mosaik.hash_size","fieldLabel":"Hash Size","renderData":{"helpPopup":"The hash size used in alignment (see Mosaik documentation).  A large value is preferred for sequences expected to be highly similar to the reference"},"minValue":0,"value":32},{"name":"mosaik.local_alignment","fieldLabel":"Local Alignment Radius","renderData":{"helpPopup":"This option is only used for paired end data.  If a value is supplied, a local alignment will be performed around paired end reads in order to attempt to rescue mates"},"minValue":0},{"name":"mosaik.max_hash_positions","fieldLabel":"Max Hash Positions","renderData":{"helpPopup":"The maximum number of hash matches that are passed to local alignment."},"minValue":0,"value":200},{"name":"mosaik.align_threshold","fieldLabel":"Alignment Threshold","renderData":{"helpPopup":"The alignment score required for an alignment to continue to local alignment.  Because the latter is slow, a higher value can improve speed."},"value":55}]');
 
+-- @SkipOnEmptySchemasBegin
 INSERT INTO sequenceanalysis.haplotype_types (type) VALUES ('MHC-IA');
 INSERT INTO sequenceanalysis.haplotype_types (type) VALUES ('MHC-IB');
 INSERT INTO sequenceanalysis.haplotype_types (type) VALUES ('MHC-II');
+-- @SkipOnEmptySchemasEnd
 
 ALTER table sequenceanalysis.haplotype_sequences DROP column haplotypeid;
 ALTER table sequenceanalysis.haplotype_sequences ADD column haplotype varchar(100);
@@ -12,6 +14,7 @@ ALTER table sequenceanalysis.haplotype_sequences ADD column required boolean;
 UPDATE sequenceanalysis.haplotype_sequences SET required = true;
 
 TRUNCATE sequenceanalysis.haplotypes;
+-- @SkipOnEmptySchemasBegin
 INSERT INTO sequenceanalysis.haplotypes (name,type) VALUES ('A001', 'MHC-IA');
 INSERT INTO sequenceanalysis.haplotypes (name,type) VALUES ('A002a', 'MHC-IA');
 INSERT INTO sequenceanalysis.haplotypes (name,type) VALUES ('A003', 'MHC-IA');
@@ -46,8 +49,10 @@ INSERT INTO sequenceanalysis.haplotypes (name,type) VALUES ('B048', 'MHC-IB');
 INSERT INTO sequenceanalysis.haplotypes (name,type) VALUES ('B055', 'MHC-IB');
 INSERT INTO sequenceanalysis.haplotypes (name,type) VALUES ('B069a', 'MHC-IB');
 INSERT INTO sequenceanalysis.haplotypes (name,type) VALUES ('B069b', 'MHC-IB');
+-- @SkipOnEmptySchemasEnd
 
 TRUNCATE sequenceanalysis.haplotype_sequences;
+-- @SkipOnEmptySchemasBegin
 INSERT INTO sequenceanalysis.haplotype_sequences (haplotype,lineage,required) VALUES ('A001', 'Mamu-A1*001g', TRUE);
 INSERT INTO sequenceanalysis.haplotype_sequences (haplotype,lineage,required) VALUES ('A001', 'Mamu-A2*05g', FALSE);
 INSERT INTO sequenceanalysis.haplotype_sequences (haplotype,lineage,required) VALUES ('A002a', 'Mamu-A1*002g', TRUE);
@@ -210,4 +215,5 @@ INSERT INTO sequenceanalysis.haplotype_sequences (haplotype,lineage,required) VA
 INSERT INTO sequenceanalysis.haplotype_sequences (haplotype,lineage,required) VALUES ('B069b', 'Mamu-B*046g', FALSE);
 INSERT INTO sequenceanalysis.haplotype_sequences (haplotype,lineage,required) VALUES ('B069b', 'Mamu-B*060g', FALSE);
 INSERT INTO sequenceanalysis.haplotype_sequences (haplotype,lineage,required) VALUES ('B069b', 'Mamu-B*072g', FALSE);
+-- @SkipOnEmptySchemasEnd
 UPDATE sequenceanalysis.haplotype_sequences SET present = true;

--- a/SequenceAnalysis/resources/schemas/dbscripts/postgresql/SequenceAnalysis-12.265-12.266.sql
+++ b/SequenceAnalysis/resources/schemas/dbscripts/postgresql/SequenceAnalysis-12.265-12.266.sql
@@ -11,6 +11,7 @@ CREATE TABLE sequenceanalysis.illumina_applications (
 );
 
 DELETE FROM sequenceanalysis.illumina_applications;
+-- @SkipOnEmptySchemasBegin
 INSERT INTO sequenceanalysis.illumina_applications (name,version,workflowname,compatiblekits,settings,workflowparams,json) VALUES ('Assembly', 1, 'Assembly', 'TruSeq LT,Nextera XT,Nextera,TruSeq HT', '{"OptionalGenome":null}', '', '');
 INSERT INTO sequenceanalysis.illumina_applications (name,version,workflowname,compatiblekits,settings,workflowparams,json) VALUES ('ChIP-Seq', 1, 'GenerateFASTQ', 'TruSeq LT', '', '', '');
 INSERT INTO sequenceanalysis.illumina_applications (name,version,workflowname,compatiblekits,settings,workflowparams,json) VALUES ('Clone Checking', 1, 'GenerateFASTQ', 'Nextera XT,Nextera,TruSeq HT,TruSeq LT', '', '', '');
@@ -23,6 +24,7 @@ INSERT INTO sequenceanalysis.illumina_applications (name,version,workflowname,co
 INSERT INTO sequenceanalysis.illumina_applications (name,version,workflowname,compatiblekits,settings,workflowparams,json) VALUES ('RNA-Seq', 1, 'GenerateFASTQ', 'TruSeq LT,TruSeq HT', '', '', '');
 INSERT INTO sequenceanalysis.illumina_applications (name,version,workflowname,compatiblekits,settings,workflowparams,json) VALUES ('Small RNA', 1, 'SmallRNA', 'Small RNA', '', '[{"Label":"Genome Folder","Type":"GENOME","LabelInSampleSheet":"GenomeFolder","TrueVal":"-","FalseVal":"-","DefaultVal":"","Required":"FALSE","DisplayAsCol":"TRUE","DisplayEvenIfEmpty":"TRUE"},{"Label":"Contaminants","Type":"STRING","LabelInSampleSheet":"Contaminants","TrueVal":"-","FalseVal":"-","DefaultVal":"","Required":"TRUE","DisplayAsCol":"TRUE","DisplayEvenIfEmpty":"FALSE"},{"Label":"RNA","Type":"STRING","LabelInSampleSheet":"RNA","TrueVal":"-","FalseVal":"-","DefaultVal":"","Required":"TRUE","DisplayAsCol":"TRUE","DisplayEvenIfEmpty":"FALSE"},{"Label":"miRNA","Type":"STRING","LabelInSampleSheet":"miRNA","TrueVal":"-","FalseVal":"-","DefaultVal":"","Required":"TRUE","DisplayAsCol":"TRUE","DisplayEvenIfEmpty":"FALSE"}]', '');
 INSERT INTO sequenceanalysis.illumina_applications (name,version,workflowname,compatiblekits,settings,workflowparams,json) VALUES ('TruSeq Amplicon', 1, 'Amplicon', 'TruSeq Amplicon', '{"Genome":null,"Manifest":null,"NoCustomPrimers":null}', '[{"Label":"Use Somatic Variant Caller (Recommended for Cancer Panel)","Type":"BOOL","LabelInSampleSheet":"VariantCaller","TrueVal":"Somatic","FalseVal":"NULL","DefaultVal":"FALSE","Required":"FALSE","DisplayAsCol":"FALSE"}]', '');
+-- @SkipOnEmptySchemasEnd
 
 CREATE TABLE sequenceanalysis.illumina_genome_folders (
   label varchar(200),
@@ -45,6 +47,7 @@ CREATE TABLE sequenceanalysis.illumina_sample_kits (
 );
 
 DELETE FROM sequenceanalysis.illumina_sample_kits;
+-- @SkipOnEmptySchemasBegin
 INSERT INTO sequenceanalysis.illumina_sample_kits (name,json) VALUES ('Nextera', '{"Settings":[["NexteraManifest"],["Adapter","CTGTCTCTTATACACATCT"],["ManifestExtension","AmpliconManifest"]]}');
 INSERT INTO sequenceanalysis.illumina_sample_kits (name,json) VALUES ('Nextera Enrichment', '{"Settings":[["Adapter","CTGTCTCTTATACACATCT"]]}');
 INSERT INTO sequenceanalysis.illumina_sample_kits (name,json) VALUES ('Nextera XT', '{"Settings":[["NexteraManifest"],["Adapter","CTGTCTCTTATACACATCT"],["ManifestExtension","AmpliconManifest"]]}');
@@ -52,5 +55,6 @@ INSERT INTO sequenceanalysis.illumina_sample_kits (name,json) VALUES ('Small RNA
 INSERT INTO sequenceanalysis.illumina_sample_kits (name,json) VALUES ('TruSeq Amplicon', '{"Settings":[["CAT"],["IndexOnly"],["PairedEndOnly"],["ManifestExtension","txt"]]}');
 INSERT INTO sequenceanalysis.illumina_sample_kits (name,json) VALUES ('TruSeq HT', '{"Settings":[["Adapter","AGATCGGAAGAGCACACGTC"]]}');
 INSERT INTO sequenceanalysis.illumina_sample_kits (name,json) VALUES ('TruSeq LT', '{"Settings":[["Adapter","AGATCGGAAGAGCACACGTC"]]}');
+-- @SkipOnEmptySchemasEnd
 
 DROP TABLE sequenceanalysis.illumina_templates;

--- a/SequenceAnalysis/resources/schemas/dbscripts/postgresql/SequenceAnalysis-12.276-12.277.sql
+++ b/SequenceAnalysis/resources/schemas/dbscripts/postgresql/SequenceAnalysis-12.276-12.277.sql
@@ -6,7 +6,9 @@ CREATE TABLE sequenceanalysis.sequence_applications (
 
 ALTER TABLE sequenceanalysis.sequence_readsets add column application varchar(200);
 
+-- @SkipOnEmptySchemasBegin
 INSERT INTO sequenceanalysis.sequence_applications (application) values ('RNA-seq');
 INSERT INTO sequenceanalysis.sequence_applications (application) values ('DNA Sequencing (Genome)');
 INSERT INTO sequenceanalysis.sequence_applications (application) values ('DNA Sequencing (Amplicon)');
 INSERT INTO sequenceanalysis.sequence_applications (application) values ('Other');
+-- @SkipOnEmptySchemasEnd

--- a/SequenceAnalysis/resources/schemas/dbscripts/postgresql/SequenceAnalysis-12.292-12.293.sql
+++ b/SequenceAnalysis/resources/schemas/dbscripts/postgresql/SequenceAnalysis-12.292-12.293.sql
@@ -74,5 +74,7 @@ CREATE TABLE sequenceanalysis.analysisSetMembers (
 
 ALTER TABLE sequenceanalysis.outputfiles drop column intermediate;
 
+-- @SkipOnEmptySchemasBegin
 INSERT INTO sequenceanalysis.sequence_applications (application) VALUES ('DNA Sequencing (Exome)');
 INSERT INTO sequenceanalysis.sequence_applications (application) VALUES ('DNA Sequencing (GBS)');
+-- @SkipOnEmptySchemasEnd

--- a/SequenceAnalysis/resources/schemas/dbscripts/postgresql/SequenceAnalysis-12.312-12.313.sql
+++ b/SequenceAnalysis/resources/schemas/dbscripts/postgresql/SequenceAnalysis-12.312-12.313.sql
@@ -6,9 +6,11 @@ CREATE TABLE sequenceanalysis.sequence_chemistries (
   CONSTRAINT PK_sequence_chemistries PRIMARY KEY (chemistry)
 );
 
+-- @SkipOnEmptySchemasBegin
 INSERT INTO sequenceanalysis.sequence_chemistries (chemistry) VALUES ('Illumina HiSeq3000');
 INSERT INTO sequenceanalysis.sequence_chemistries (chemistry) VALUES ('Illumina MiSeq 2x250');
 INSERT INTO sequenceanalysis.sequence_chemistries (chemistry) VALUES ('Illumina MiSeq 2x300');
 INSERT INTO sequenceanalysis.sequence_chemistries (chemistry) VALUES ('Illumina XTen');
 INSERT INTO sequenceanalysis.sequence_chemistries (chemistry) VALUES ('Illumina NextSeq MidOutput');
 INSERT INTO sequenceanalysis.sequence_chemistries (chemistry) VALUES ('Illumina NextSeq HighOutput');
+-- @SkipOnEmptySchemasEnd

--- a/SequenceAnalysis/resources/schemas/dbscripts/postgresql/SequenceAnalysis-12.316-12.317.sql
+++ b/SequenceAnalysis/resources/schemas/dbscripts/postgresql/SequenceAnalysis-12.316-12.317.sql
@@ -6,7 +6,9 @@ ALTER TABLE sequenceanalysis.instrument_runs DROP instrumentid;
 
 ALTER TABLE sequenceanalysis.saved_analyses ALTER COLUMN json TYPE text;
 
+-- @SkipOnEmptySchemasBegin
 INSERT into sequenceanalysis.instruments (displayname, platform) VALUES ('MiSeq', 'ILLUMINA');
 INSERT into sequenceanalysis.instruments (displayname, platform) VALUES ('HiSeq3000', 'ILLUMINA');
 INSERT into sequenceanalysis.instruments (displayname, platform) VALUES ('HiSeq2500', 'ILLUMINA');
 INSERT into sequenceanalysis.instruments (displayname, platform) VALUES ('NovaSeq', 'ILLUMINA');
+-- @SkipOnEmptySchemasEnd


### PR DESCRIPTION
#### Rationale
The first step of SQL Server -> PostgreSQL migration is creating empty schemas. In that case, we don't want to save any properties.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6867