### PR TITLE
 Support BIGINT Primary Keys

### DIFF
--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/RefNtSequenceModel.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/RefNtSequenceModel.java
@@ -62,7 +62,7 @@ public class RefNtSequenceModel implements Serializable
     //deprecated
     private String _sequence;
     private Long _sequenceFile;
-    private Integer _jobId;
+    private Long _jobId;
     private String _category;
     private String _subset;
     private String _locus;
@@ -361,12 +361,12 @@ public class RefNtSequenceModel implements Serializable
         _modified = modified;
     }
 
-    public Integer getJobId()
+    public Long getJobId()
     {
         return _jobId;
     }
 
-    public void setJobId(Integer jobId)
+    public void setJobId(Long jobId)
     {
         _jobId = jobId;
     }

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/RefNtSequenceModel.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/RefNtSequenceModel.java
@@ -61,7 +61,7 @@ public class RefNtSequenceModel implements Serializable
     private String _name;
     //deprecated
     private String _sequence;
-    private Integer _sequenceFile;
+    private Long _sequenceFile;
     private Integer _jobId;
     private String _category;
     private String _subset;
@@ -171,12 +171,12 @@ public class RefNtSequenceModel implements Serializable
         _sequence = sequence;
     }
 
-    public Integer getSequenceFile()
+    public Long getSequenceFile()
     {
         return _sequenceFile;
     }
 
-    public void setSequenceFile(Integer sequenceFile)
+    public void setSequenceFile(Long sequenceFile)
     {
         _sequenceFile = sequenceFile;
     }

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/SequenceAnalysisService.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/SequenceAnalysisService.java
@@ -87,7 +87,7 @@ abstract public class SequenceAnalysisService
 
     abstract public String getUnzippedBaseName(String filename);
 
-    abstract public Integer getExpRunIdForJob(PipelineJob job, boolean throwUnlessFound) throws PipelineJobException;
+    abstract public Long getExpRunIdForJob(PipelineJob job, boolean throwUnlessFound) throws PipelineJobException;
 
     abstract public List<PedigreeRecord> generatePedigree(Collection<String> sampleNames, Container c, User u, DemographicsProvider d);
 

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/SequenceAnalysisService.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/SequenceAnalysisService.java
@@ -69,7 +69,7 @@ abstract public class SequenceAnalysisService
 
     abstract public ReadData getReadData(int rowId, User u);
 
-    abstract public Readset getReadset(int readsetId, User u);
+    abstract public Readset getReadset(long readsetId, User u);
 
     abstract public ReferenceGenome getReferenceGenome(int rowId, User u) throws PipelineJobException;
 

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/SequenceOutputFile.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/SequenceOutputFile.java
@@ -39,8 +39,8 @@ public class SequenceOutputFile implements Serializable
     private String _description;
     private Long _dataId;
     private Integer _library_id;
-    private Integer _readset;
-    private Integer _analysis_id;
+    private Long _readset;
+    private Long _analysis_id;
     private Long _runid;
     private String _category;
     private Boolean _intermediate;
@@ -106,22 +106,22 @@ public class SequenceOutputFile implements Serializable
         _library_id = library_id;
     }
 
-    public Integer getReadset()
+    public Long getReadset()
     {
         return _readset;
     }
 
-    public void setReadset(Integer readset)
+    public void setReadset(Long readset)
     {
         _readset = readset;
     }
 
-    public Integer getAnalysis_id()
+    public Long getAnalysis_id()
     {
         return _analysis_id;
     }
 
-    public void setAnalysis_id(Integer analysis_id)
+    public void setAnalysis_id(Long analysis_id)
     {
         _analysis_id = analysis_id;
     }

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/SequenceOutputFile.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/SequenceOutputFile.java
@@ -37,11 +37,11 @@ public class SequenceOutputFile implements Serializable
     private Integer _rowid;
     private String _name;
     private String _description;
-    private Integer _dataId;
+    private Long _dataId;
     private Integer _library_id;
     private Integer _readset;
     private Integer _analysis_id;
-    private Integer _runid;
+    private Long _runid;
     private String _category;
     private Boolean _intermediate;
     private String _container;
@@ -86,12 +86,12 @@ public class SequenceOutputFile implements Serializable
         _description = description;
     }
 
-    public Integer getDataId()
+    public Long getDataId()
     {
         return _dataId;
     }
 
-    public void setDataId(Integer dataId)
+    public void setDataId(Long dataId)
     {
         _dataId = dataId;
     }
@@ -126,12 +126,12 @@ public class SequenceOutputFile implements Serializable
         _analysis_id = analysis_id;
     }
 
-    public Integer getRunId()
+    public Long getRunId()
     {
         return _runid;
     }
 
-    public void setRunId(Integer runid)
+    public void setRunId(Long runid)
     {
         _runid = runid;
     }

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/model/AnalysisModel.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/model/AnalysisModel.java
@@ -33,22 +33,22 @@ public interface AnalysisModel extends Serializable
 {
     Integer getAnalysisId();
 
-    Integer getRunId();
+    Long getRunId();
 
     String getContainer();
 
     Integer getReadset();
 
-    Integer getAlignmentFile();
+    Long getAlignmentFile();
 
     File getAlignmentFileObject();
 
     ExpData getAlignmentData();
 
     @Deprecated
-    Integer getReferenceLibrary();
+    Long getReferenceLibrary();
 
-    void setReferenceLibrary(Integer libraryId);
+    void setReferenceLibrary(Long libraryId);
 
     ExpData getReferenceLibraryData(User u) throws PipelineJobException;
 

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/model/AnalysisModel.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/model/AnalysisModel.java
@@ -31,13 +31,13 @@ import java.util.Date;
  */
 public interface AnalysisModel extends Serializable
 {
-    Integer getAnalysisId();
+    Long getAnalysisId();
 
     Long getRunId();
 
     String getContainer();
 
-    Integer getReadset();
+    Long getReadset();
 
     Long getAlignmentFile();
 
@@ -64,7 +64,7 @@ public interface AnalysisModel extends Serializable
 
     Integer getCreatedby();
 
-    Integer getRowId();
+    Long getRowId();
 
     String getDescription();
 

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/model/ReadData.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/model/ReadData.java
@@ -24,9 +24,9 @@ import java.util.Date;
  */
 public interface ReadData extends Serializable
 {
-    Integer getRowid();
+    Long getRowid();
 
-    Integer getReadset();
+    Long getReadset();
 
     String getPlatformUnit();
 

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/model/ReadData.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/model/ReadData.java
@@ -34,9 +34,9 @@ public interface ReadData extends Serializable
 
     Date getDate();
 
-    Integer getFileId1();
+    Long getFileId1();
 
-    Integer getFileId2();
+    Long getFileId2();
 
     File getFile1();
 
@@ -44,7 +44,7 @@ public interface ReadData extends Serializable
 
     String getDescription();
 
-    Integer getRunId();
+    Long getRunId();
 
     String getContainer();
 

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/model/Readset.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/model/Readset.java
@@ -46,7 +46,7 @@ public interface Readset extends Serializable
 
     Integer getInstrumentRunId();
 
-    Integer getReadsetId();
+    Long getReadsetId();
 
     String getBarcode5();
 
@@ -56,7 +56,7 @@ public interface Readset extends Serializable
 
     Double getConcentration();
 
-    int getRowId();
+    long getRowId();
 
     String getContainer();
 

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/model/Readset.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/model/Readset.java
@@ -72,7 +72,7 @@ public interface Readset extends Serializable
 
     String getStatus();
 
-    Integer getRunId();
+    Long getRunId();
 
     boolean hasPairedData();
 

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/DefaultPipelineStepOutput.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/DefaultPipelineStepOutput.java
@@ -103,7 +103,7 @@ public class DefaultPipelineStepOutput implements PipelineStepOutput
     }
 
     @Override
-    public void addSequenceOutput(File file, String label, String category, @Nullable Integer readsetId, @Nullable Integer analysisId, @Nullable Integer genomeId, @Nullable String description)
+    public void addSequenceOutput(File file, String label, String category, @Nullable Long readsetId, @Nullable Long analysisId, @Nullable Integer genomeId, @Nullable String description)
     {
         _intermediateFiles.remove(file);
 

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/PipelineOutputTracker.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/PipelineOutputTracker.java
@@ -17,7 +17,7 @@ public interface PipelineOutputTracker
     /**
      * Add a SequenceOutputFile for this job.  These files are tracked and displayed through the browser UI.
      */
-    void addSequenceOutput(File file, String label, String category, @Nullable Integer readsetId, @Nullable Integer analysisId, @Nullable Integer genomeId, @Nullable String description);
+    void addSequenceOutput(File file, String label, String category, @Nullable Long readsetId, @Nullable Long analysisId, @Nullable Integer genomeId, @Nullable String description);
 
     /**
      * Remove a previously added intermediate file

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/PipelineStepOutput.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/PipelineStepOutput.java
@@ -92,12 +92,12 @@ public interface PipelineStepOutput extends PipelineOutputTracker
         private final File _file;
         private final String _label;
         private final String _category;
-        private final Integer _readsetId;
-        private final Integer _analysisId;
+        private final Long _readsetId;
+        private final Long _analysisId;
         private final Integer _genomeId;
         private final String _description;
 
-        public SequenceOutput(File file, String label, String category, @Nullable Integer readsetId, @Nullable Integer analysisId, @Nullable Integer genomeId, @Nullable String description)
+        public SequenceOutput(File file, String label, String category, @Nullable Long readsetId, @Nullable Long analysisId, @Nullable Integer genomeId, @Nullable String description)
         {
             _file = file;
             _label = label;
@@ -123,12 +123,12 @@ public interface PipelineStepOutput extends PipelineOutputTracker
             return _category;
         }
 
-        public Integer getReadsetId()
+        public Long getReadsetId()
         {
             return _readsetId;
         }
 
-        public Integer getAnalysisId()
+        public Long getAnalysisId()
         {
             return _analysisId;
         }
@@ -148,7 +148,7 @@ public interface PipelineStepOutput extends PipelineOutputTracker
     {
         File _metricFile;
         File _inputFile;
-        Integer _readsetId;
+        Long _readsetId;
         TYPE _type;
 
         public enum TYPE
@@ -157,7 +157,7 @@ public interface PipelineStepOutput extends PipelineOutputTracker
             reads()
         }
 
-        public PicardMetricsOutput(File metricFile, File inputFile, Integer readsetId)
+        public PicardMetricsOutput(File metricFile, File inputFile, Long readsetId)
         {
             _metricFile = metricFile;
             _inputFile = inputFile;
@@ -170,7 +170,7 @@ public interface PipelineStepOutput extends PipelineOutputTracker
          * want to denote that these metrics will apply to the final file, but dont know its name yet.  This can be used instead of tying the
          * metrics to a specific file.
          */
-        public PicardMetricsOutput(File metricFile, TYPE type, Integer readsetId)
+        public PicardMetricsOutput(File metricFile, TYPE type, Long readsetId)
         {
             _metricFile = metricFile;
             _type = type;
@@ -187,7 +187,7 @@ public interface PipelineStepOutput extends PipelineOutputTracker
             return _inputFile;
         }
 
-        public Integer getReadsetId()
+        public Long getReadsetId()
         {
             return _readsetId;
         }

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/ReferenceGenome.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/ReferenceGenome.java
@@ -75,7 +75,7 @@ public interface ReferenceGenome extends Serializable
      * this will correspond to the permanent FASTA, as opposed to the copy used in this job.  If this FASTA was created specifically for
      * this job then the FASTA will be in the analysis directory.
      */
-    Integer getFastaExpDataId();
+    Long getFastaExpDataId();
 
     /**
      * @param name The name used by the aligner to identify its cached directory

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/SequenceAnalysisJobSupport.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/SequenceAnalysisJobSupport.java
@@ -35,9 +35,9 @@ public interface SequenceAnalysisJobSupport extends Serializable
 {
     void cacheExpData(ExpData data);
 
-    File getCachedData(int dataId);
+    File getCachedData(long dataId);
 
-    Map<Integer, File> getAllCachedData();
+    Map<Long, File> getAllCachedData();
 
     Readset getCachedReadset(Integer rowId);
 

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/SequenceAnalysisJobSupport.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/SequenceAnalysisJobSupport.java
@@ -39,15 +39,15 @@ public interface SequenceAnalysisJobSupport extends Serializable
 
     Map<Long, File> getAllCachedData();
 
-    Readset getCachedReadset(Integer rowId);
+    Readset getCachedReadset(Long rowId);
 
-    AnalysisModel getCachedAnalysis(int rowId);
+    AnalysisModel getCachedAnalysis(long rowId);
 
     List<Readset> getCachedReadsets();
 
-    void cacheReadset(int readsetId, User u);
+    void cacheReadset(long readsetId, User u);
 
-    void cacheReadset(int readsetId, User u, boolean allowReadsetsWithArchivedData);
+    void cacheReadset(long readsetId, User u, boolean allowReadsetsWithArchivedData);
 
     List<AnalysisModel> getCachedAnalyses();
 

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/SequencePipelineService.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/SequencePipelineService.java
@@ -115,7 +115,7 @@ abstract public class SequencePipelineService
     /**
      * Throws exception if no run is found
      */
-    abstract public Integer getExpRunIdForJob(PipelineJob job) throws PipelineJobException;
+    abstract public Long getExpRunIdForJob(PipelineJob job) throws PipelineJobException;
 
     abstract public long getLineCount(File f) throws PipelineJobException;
 
@@ -140,7 +140,7 @@ abstract public class SequencePipelineService
 
     abstract public boolean hasMinLineCount(File f, long minLines) throws PipelineJobException;
 
-    abstract public void updateOutputFile(SequenceOutputFile o, PipelineJob job, Integer runId, Integer analysisId);
+    abstract public void updateOutputFile(SequenceOutputFile o, PipelineJob job, Long runId, Integer analysisId);
 
     abstract public PreprocessingStep.Output simpleTrimFastqPair(File fq1, File fq2, List<String> params, File outDir, Logger log) throws PipelineJobException;
 

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/SequencePipelineService.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/SequencePipelineService.java
@@ -140,7 +140,7 @@ abstract public class SequencePipelineService
 
     abstract public boolean hasMinLineCount(File f, long minLines) throws PipelineJobException;
 
-    abstract public void updateOutputFile(SequenceOutputFile o, PipelineJob job, Long runId, Integer analysisId);
+    abstract public void updateOutputFile(SequenceOutputFile o, PipelineJob job, Long runId, Long analysisId);
 
     abstract public PreprocessingStep.Output simpleTrimFastqPair(File fq1, File fq2, List<String> params, File outDir, Logger log) throws PipelineJobException;
 

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/TaskFileManager.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/TaskFileManager.java
@@ -62,11 +62,11 @@ public interface TaskFileManager extends PipelineOutputTracker
 
     void addPicardMetricsFiles(List<PipelineStepOutput.PicardMetricsOutput> files) throws PipelineJobException;
 
-    void writeMetricsToDb(Map<Integer, Integer> readsetMap, Map<Integer, Map<PipelineStepOutput.PicardMetricsOutput.TYPE, File>> typeMap) throws PipelineJobException;
+    void writeMetricsToDb(Map<Long, Long> readsetMap, Map<Long, Map<PipelineStepOutput.PicardMetricsOutput.TYPE, File>> typeMap) throws PipelineJobException;
 
     void deleteIntermediateFiles() throws PipelineJobException;
 
-    Set<SequenceOutputFile> createSequenceOutputRecords(@Nullable Integer analysisId)throws PipelineJobException;
+    Set<SequenceOutputFile> createSequenceOutputRecords(@Nullable Long analysisId)throws PipelineJobException;
 
     //should be used for remote jobs or local jobs running in a separate working directory
     void cleanup(Collection<RecordedAction> actions) throws PipelineJobException;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/OutputIntegrationTests.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/OutputIntegrationTests.java
@@ -49,6 +49,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.labkey.api.exp.api.ExperimentService.asInteger;
+
 /**
  * Created by bimber on 9/18/2016.
  */
@@ -235,7 +237,7 @@ public class OutputIntegrationTests
 
             params = Table.insert(TestContext.get().getUser(), SequenceAnalysisSchema.getTable(SequenceAnalysisSchema.TABLE_OUTPUTFILES), params);
 
-            return (Integer)params.get("rowid");
+            return asInteger(params.get("rowid"));
         }
     }
 }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/ReadDataImpl.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/ReadDataImpl.java
@@ -28,15 +28,15 @@ public class ReadDataImpl implements ReadData
     private String _platformUnit;
     private String _centerName;
     private Date _date;
-    private Integer _fileId1;
-    private Integer _fileId2;
+    private Long _fileId1;
+    private Long _fileId2;
     private String _description;
     private String _container;
     private Date _created;
     private Integer _createdBy;
     private Date _modified;
     private Integer _modifiedBy;
-    private Integer _runId;
+    private Long _runId;
     private boolean _archived = false;
     private String sra_accession;
 
@@ -103,23 +103,23 @@ public class ReadDataImpl implements ReadData
     }
 
     @Override
-    public Integer getFileId1()
+    public Long getFileId1()
     {
         return _fileId1;
     }
 
-    public void setFileId1(Integer fileId1)
+    public void setFileId1(Long fileId1)
     {
         _fileId1 = fileId1;
     }
 
     @Override
-    public Integer getFileId2()
+    public Long getFileId2()
     {
         return _fileId2;
     }
 
-    public void setFileId2(Integer fileId2)
+    public void setFileId2(Long fileId2)
     {
         _fileId2 = fileId2;
     }
@@ -131,12 +131,12 @@ public class ReadDataImpl implements ReadData
     }
 
     @Override
-    public Integer getRunId()
+    public Long getRunId()
     {
         return _runId;
     }
 
-    public void setRunId(Integer runId)
+    public void setRunId(Long runId)
     {
         _runId = runId;
     }
@@ -258,7 +258,7 @@ public class ReadDataImpl implements ReadData
     }
 
     @Transient
-    private File getFile(int fileIdx, Integer fileId, boolean allowArchived)
+    private File getFile(int fileIdx, Long fileId, boolean allowArchived)
     {
         if (isArchived() && !allowArchived)
         {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/ReadDataImpl.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/ReadDataImpl.java
@@ -23,8 +23,8 @@ import java.util.Map;
  */
 public class ReadDataImpl implements ReadData
 {
-    private Integer _rowid;
-    private Integer _readset;
+    private Long _rowid;
+    private Long _readset;
     private String _platformUnit;
     private String _centerName;
     private Date _date;
@@ -48,23 +48,23 @@ public class ReadDataImpl implements ReadData
     }
 
     @Override
-    public Integer getRowid()
+    public Long getRowid()
     {
         return _rowid;
     }
 
-    public void setRowid(Integer rowid)
+    public void setRowid(Long rowid)
     {
         _rowid = rowid;
     }
 
     @Override
-    public Integer getReadset()
+    public Long getReadset()
     {
         return _readset;
     }
 
-    public void setReadset(Integer readset)
+    public void setReadset(Long readset)
     {
         _readset = readset;
     }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/ReadDataImpl.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/ReadDataImpl.java
@@ -1,5 +1,6 @@
 package org.labkey.sequenceanalysis;
 
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
@@ -14,7 +15,6 @@ import org.labkey.api.util.PageFlowUtil;
 
 import java.io.File;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -40,7 +40,7 @@ public class ReadDataImpl implements ReadData
     private boolean _archived = false;
     private String sra_accession;
 
-    private final Map<Integer, File> _cachedFiles = new HashMap<>();
+    private final Map<Integer, File> _cachedFiles = new IntHashMap<>();
 
     public ReadDataImpl()
     {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisController.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisController.java
@@ -503,15 +503,15 @@ public class SequenceAnalysisController extends SpringActionController
 
     public static class DeleteForm extends QueryForm
     {
-        private Integer[] _jobIds;
+        private Long[] _jobIds;
         private boolean _doDelete = false;
 
-        public Integer[] getJobIds()
+        public Long[] getJobIds()
         {
             return _jobIds;
         }
 
-        public void setJobIds(Integer[] jobIds)
+        public void setJobIds(Long[] jobIds)
         {
             _jobIds = jobIds;
         }
@@ -2916,7 +2916,7 @@ public class SequenceAnalysisController extends SpringActionController
                     String header = se.eval(rs.getFieldKeyRowMap());
                     RefNtSequenceModel model = new RefNtSequenceModel();
                     if (rs.getObject(FieldKey.fromString("sequenceFile")) != null)
-                        model.setSequenceFile(rs.getInt(FieldKey.fromString("sequenceFile")));
+                        model.setSequenceFile(rs.getLong(FieldKey.fromString("sequenceFile")));
 
                     model.setContainer(rs.getString(FieldKey.fromString("container")));
 

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisController.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisController.java
@@ -53,6 +53,8 @@ import org.labkey.api.action.SpringActionController;
 import org.labkey.api.assay.AssayFileWriter;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
+import org.labkey.api.collections.IntHashMap;
+import org.labkey.api.collections.IntHashSet;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
@@ -596,11 +598,11 @@ public class SequenceAnalysisController extends SpringActionController
                 keys.add(ConvertHelper.convert(key, Integer.class));
             }
 
-            Set<Integer> expRunsToDelete = new HashSet<>();
-            Set<Integer> readsetIds = new HashSet<>();
-            Set<Integer> readDataIds = new HashSet<>();
-            Set<Integer> analysisIds = new HashSet<>();
-            Set<Integer> outputFileIds = new HashSet<>();
+            Set<Integer> expRunsToDelete = new IntHashSet();
+            Set<Integer> readsetIds = new IntHashSet();
+            Set<Integer> readDataIds = new IntHashSet();
+            Set<Integer> analysisIds = new IntHashSet();
+            Set<Integer> outputFileIds = new IntHashSet();
 
             StringBuilder msg = new StringBuilder("Are you sure you want to delete the following " + keys.size() + " ");
             if (SequenceAnalysisSchema.TABLE_ANALYSES.equals(_table.getName()))
@@ -753,7 +755,7 @@ public class SequenceAnalysisController extends SpringActionController
 
         private void getAdditionalRuns(Set<Integer> readsetIds, Set<Integer> readDataIds, Set<Integer> analysisIds, Set<Integer> outputFileIds, Set<Integer> expRunsToDelete)
         {
-            Set<Integer> runIdsStillInUse = new HashSet<>();
+            Set<Integer> runIdsStillInUse = new IntHashSet();
 
             //work backwards, adding additional pipeline jobs that will become orphans:
             runIdsStillInUse.addAll(getRunIdsInUse(SequenceAnalysisSchema.TABLE_READSETS, expRunsToDelete, readsetIds));
@@ -786,7 +788,7 @@ public class SequenceAnalysisController extends SpringActionController
         {
             SimpleFilter filter = new SimpleFilter(FieldKey.fromString(filterCol), keys, CompareType.IN);
             TableSelector ts = new TableSelector(SequenceAnalysisSchema.getInstance().getSchema().getTable(tableName), PageFlowUtil.set(pkCol), filter, null);
-            Set<Integer> total = new HashSet<>(ts.getArrayList(Integer.class));
+            Set<Integer> total = new IntHashSet(ts.getArrayList(Integer.class));
             sb.append("<br>" + total.size() + " " + noun);
 
             return total;
@@ -1164,7 +1166,7 @@ public class SequenceAnalysisController extends SpringActionController
 
                         if (readsets1.length > 0 || readsets2.length > 0)
                         {
-                            Set<Integer> ids = new HashSet<>();
+                            Set<Integer> ids = new IntHashSet();
                             ids.addAll(Arrays.asList(readsets1));
                             ids.addAll(Arrays.asList(readsets2));
 
@@ -3888,7 +3890,7 @@ public class SequenceAnalysisController extends SpringActionController
 
         protected void validateGenomes(List<SequenceOutputFile> inputs, SequenceOutputHandler<?> handler) throws IllegalArgumentException
         {
-            Set<Integer> genomes = new HashSet<>();
+            Set<Integer> genomes = new IntHashSet();
             inputs.forEach(x -> {
                 if (x.getLibrary_id() == null && (handler.requiresGenome() || handler.requiresSingleGenome()))
                 {
@@ -4897,7 +4899,7 @@ public class SequenceAnalysisController extends SpringActionController
         {
             Map<String, Object> resp = new HashMap<>();
 
-            Map<Integer, JSONObject> fileMap = new HashMap<>();
+            Map<Integer, JSONObject> fileMap = new IntHashMap<>();
             for (Integer rowId : form.getOutputFileIds())
             {
                 SequenceOutputFile f = SequenceOutputFile.getForId(rowId);

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisController.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisController.java
@@ -209,6 +209,7 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import static org.labkey.api.exp.api.ExperimentService.asInteger;
 import static org.labkey.sequenceanalysis.SequenceIntegrationTests.PIPELINE_PROP_NAME;
 
 public class SequenceAnalysisController extends SpringActionController
@@ -3239,8 +3240,8 @@ public class SequenceAnalysisController extends SpringActionController
                         continue;
                     }
 
-                    Integer dataId = (Integer) rowMap.get("dataid");
-                    Integer libraryId = (Integer) rowMap.get("library_id");
+                    Integer dataId = asInteger(rowMap.get("dataid"));
+                    Integer libraryId = asInteger(rowMap.get("library_id"));
                     ExpData d = ExperimentService.get().getExpData(dataId);
                     if (d == null)
                     {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisMaintenanceTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisMaintenanceTask.java
@@ -4,6 +4,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
@@ -42,7 +43,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -101,7 +101,7 @@ public class SequenceAnalysisMaintenanceTask implements MaintenanceTask
                 {
                     try
                     {
-                        Map<Integer, File> genomeMap = new HashMap<>();
+                        Map<Integer, File> genomeMap = new IntHashMap<>();
                         new TableSelector(SequenceAnalysisSchema.getInstance().getSchema().getTable(SequenceAnalysisSchema.TABLE_REF_LIBRARIES), PageFlowUtil.set("rowid", "fasta_file"), new SimpleFilter(FieldKey.fromString("datedisabled"), null, CompareType.ISBLANK), null).forEachResults(rs -> {
                             int dataId = rs.getInt(FieldKey.fromString("fasta_file"));
                             if (dataId > -1)

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisMaintenanceTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisMaintenanceTask.java
@@ -239,7 +239,7 @@ public class SequenceAnalysisMaintenanceTask implements MaintenanceTask
         }
     }
 
-    private void inspectForCoreFiles(Integer runId, Logger log)
+    private void inspectForCoreFiles(Long runId, Logger log)
     {
         if (runId == null)
         {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisManager.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisManager.java
@@ -280,9 +280,9 @@ public class SequenceAnalysisManager
                 throw new IllegalArgumentException("Unable to find sequenceanalysis user schema");
             }
 
-            Set<Integer> bamsDeleted = new HashSet<>();
+            Set<Long> bamsDeleted = new HashSet<>();
             Set<Integer> outputFilesWithDataNotDeleted = new HashSet<>();
-            Set<Integer> expDataDeleted = new HashSet<>();
+            Set<Long> expDataDeleted = new HashSet<>();
             List<SequenceOutputFile> files = new TableSelector(SequenceAnalysisSchema.getTable(SequenceAnalysisSchema.TABLE_OUTPUTFILES), new SimpleFilter(FieldKey.fromString("rowid"), outputFileIds, CompareType.IN), null).getArrayList(SequenceOutputFile.class);
             for (SequenceOutputFile so : files)
             {
@@ -728,7 +728,7 @@ public class SequenceAnalysisManager
         }
     }
 
-    public List<Integer> importRefSequencesFromFasta(Container c, User u, File file, boolean splitWhitespace, Map<String, String> params, Logger log, @Nullable File outDir, @Nullable Integer jobId) throws IOException
+    public List<Integer> importRefSequencesFromFasta(Container c, User u, File file, boolean splitWhitespace, Map<String, String> params, Logger log, @Nullable File outDir, @Nullable Long jobId) throws IOException
     {
         PipeRoot root = PipelineService.get().getPipelineRootSetting(c);
         if (root == null)

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisManager.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisManager.java
@@ -91,6 +91,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.labkey.api.exp.api.ExperimentService.asInteger;
+
 public class SequenceAnalysisManager
 {
     private static final SequenceAnalysisManager _instance = new SequenceAnalysisManager();
@@ -783,7 +785,7 @@ public class SequenceAnalysisManager
                         map.put("jobId", jobId);
 
                     map = Table.insert(u, dnaTable, map);
-                    sequenceIds.add((Integer) map.get("rowid"));
+                    sequenceIds.add(asInteger(map.get("rowid")));
 
                     RefNtSequenceModel m = new TableSelector(dnaTable, new SimpleFilter(FieldKey.fromString("rowid"), map.get("rowid")), null).getObject(RefNtSequenceModel.class);
 

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisServiceImpl.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisServiceImpl.java
@@ -69,6 +69,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
+import static org.labkey.api.exp.api.ExperimentService.asLong;
+
 /**
  * User: bimber
  * Date: 10/27/13
@@ -231,7 +233,7 @@ public class SequenceAnalysisServiceImpl extends SequenceAnalysisService
             throw new UnauthorizedException("Cannot read data in container: " + c.getPath());
         }
 
-        ExpData d = ExperimentService.get().getExpData((Integer)map.get("fasta_file"));
+        ExpData d = ExperimentService.get().getExpData(asLong(map.get("fasta_file")));
         if (d.getFile() == null)
         {
             throw new PipelineJobException("No FASTA file found for genome: " + genomeId);

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisServiceImpl.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisServiceImpl.java
@@ -193,7 +193,7 @@ public class SequenceAnalysisServiceImpl extends SequenceAnalysisService
     }
 
     @Override
-    public SequenceReadsetImpl getReadset(int readsetId, User u)
+    public SequenceReadsetImpl getReadset(long readsetId, User u)
     {
         TableInfo ti = SequenceAnalysisSchema.getTable(SequenceAnalysisSchema.TABLE_READSETS);
         SimpleFilter filter = new SimpleFilter(FieldKey.fromString("rowid"), readsetId);

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisServiceImpl.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisServiceImpl.java
@@ -363,7 +363,7 @@ public class SequenceAnalysisServiceImpl extends SequenceAnalysisService
     }
 
     @Override
-    public Integer getExpRunIdForJob(PipelineJob job, boolean throwUnlessFound) throws PipelineJobException
+    public Long getExpRunIdForJob(PipelineJob job, boolean throwUnlessFound) throws PipelineJobException
     {
         return SequenceTaskHelper.getExpRunIdForJob(job, throwUnlessFound);
     }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceIntegrationTests.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceIntegrationTests.java
@@ -90,6 +90,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.labkey.api.exp.api.ExperimentService.asInteger;
+
 /**
  * User: bimber
  * Date: 11/25/12
@@ -1753,11 +1755,11 @@ public class SequenceIntegrationTests
             if (ts.exists())
             {
                 Map<String, Object> rowMap = ts.getMap();
-                Integer fasta_file = (Integer)rowMap.get("fasta_file");
+                Integer fasta_file = asInteger(rowMap.get("fasta_file"));
                 ExpData d = fasta_file == null ? null : ExperimentService.get().getExpData(fasta_file);
                 if (d != null && d.getFile() != null && d.getFile().exists())
                 {
-                    return (Integer) rowMap.get("rowid");
+                    return asInteger(rowMap.get("rowid"));
                 }
                 else
                 {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceIntegrationTests.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceIntegrationTests.java
@@ -1452,7 +1452,7 @@ public class SequenceIntegrationTests
             }
         }
 
-        private SequenceReadsetImpl[] getReadsetsForJob(int runId)
+        private SequenceReadsetImpl[] getReadsetsForJob(long runId)
         {
             TableInfo ti = SequenceAnalysisSchema.getTable(SequenceAnalysisSchema.TABLE_READSETS);
             TableSelector ts = new TableSelector(ti, new SimpleFilter(FieldKey.fromString("runid"), runId), null);

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequencePipelineServiceImpl.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequencePipelineServiceImpl.java
@@ -610,7 +610,7 @@ public class SequencePipelineServiceImpl extends SequencePipelineService
     }
 
     @Override
-    public void updateOutputFile(SequenceOutputFile o, PipelineJob job, Long runId, Integer analysisId)
+    public void updateOutputFile(SequenceOutputFile o, PipelineJob job, Long runId, Long analysisId)
     {
         SequenceOutputHandlerFinalTask.updateOutputFile(o, job, runId, analysisId);
     }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequencePipelineServiceImpl.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequencePipelineServiceImpl.java
@@ -518,7 +518,7 @@ public class SequencePipelineServiceImpl extends SequencePipelineService
     }
 
     @Override
-    public Integer getExpRunIdForJob(PipelineJob job) throws PipelineJobException
+    public Long getExpRunIdForJob(PipelineJob job) throws PipelineJobException
     {
         return SequenceTaskHelper.getExpRunIdForJob(job);
     }
@@ -610,7 +610,7 @@ public class SequencePipelineServiceImpl extends SequencePipelineService
     }
 
     @Override
-    public void updateOutputFile(SequenceOutputFile o, PipelineJob job, Integer runId, Integer analysisId)
+    public void updateOutputFile(SequenceOutputFile o, PipelineJob job, Long runId, Integer analysisId)
     {
         SequenceOutputHandlerFinalTask.updateOutputFile(o, job, runId, analysisId);
     }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceReadsetImpl.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceReadsetImpl.java
@@ -34,7 +34,7 @@ import java.util.List;
  */
 public class SequenceReadsetImpl implements Readset
 {
-    private Integer _rowId;
+    private Long _rowId;
     private String _name;
     private String _comments;
     private String _platform;
@@ -67,7 +67,7 @@ public class SequenceReadsetImpl implements Readset
     }
 
     @Override
-    public int getRowId()
+    public long getRowId()
     {
         return _rowId == null ? 0 : _rowId;
     }
@@ -77,7 +77,7 @@ public class SequenceReadsetImpl implements Readset
         _rowId = null;
     }
 
-    public void setRowId(int rowId)
+    public void setRowId(long rowId)
     {
         _rowId = rowId;
     }
@@ -89,7 +89,7 @@ public class SequenceReadsetImpl implements Readset
 
     @Override
     @JsonIgnore
-    public Integer getReadsetId()
+    public Long getReadsetId()
     {
         return _rowId;
     }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceReadsetImpl.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceReadsetImpl.java
@@ -50,7 +50,7 @@ public class SequenceReadsetImpl implements Readset
     private Double _fragmentSize;
     private Double _concentration;
     private Integer _instrument_run_id;
-    private Integer _runId;
+    private Long _runId;
     private String _status;
     private String _container;
     private Date _created;
@@ -259,12 +259,12 @@ public class SequenceReadsetImpl implements Readset
     }
 
     @Override
-    public Integer getRunId()
+    public Long getRunId()
     {
         return _runId;
     }
 
-    public void setRunId(Integer runId)
+    public void setRunId(Long runId)
     {
         _runId = runId;
     }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/CombineStarGeneCountsHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/CombineStarGeneCountsHandler.java
@@ -1,6 +1,7 @@
 package org.labkey.sequenceanalysis.analysis;
 
 import org.json.JSONObject;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.pipeline.RecordedAction;
@@ -41,9 +42,9 @@ public class CombineStarGeneCountsHandler extends AbstractCombineGeneCountsHandl
         long totalStrand2 = 0L;
 
         results.distinctGenes.addAll(translator.getGeneMap().keySet());
-        Map<Integer, Map<String, Double>> unstrandedCounts = new HashMap<>(inputFiles.size());
-        Map<Integer, Map<String, Double>> strand1Counts = new HashMap<>(inputFiles.size());
-        Map<Integer, Map<String, Double>> strand2Counts = new HashMap<>(inputFiles.size());
+        Map<Integer, Map<String, Double>> unstrandedCounts = new IntHashMap<>(inputFiles.size());
+        Map<Integer, Map<String, Double>> strand1Counts = new IntHashMap<>(inputFiles.size());
+        Map<Integer, Map<String, Double>> strand2Counts = new IntHashMap<>(inputFiles.size());
 
         for (SequenceOutputFile so : inputFiles)
         {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/MultiQCBamHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/MultiQCBamHandler.java
@@ -77,7 +77,7 @@ public class MultiQCBamHandler extends AbstractParameterizedOutputHandler<Sequen
             action.setStartTime(new Date());
 
             Set<File> dirs = new HashSet<>();
-            Set<Integer> readsets = new HashSet<>();
+            Set<Long> readsets = new HashSet<>();
             Set<Integer> genomes = new HashSet<>();
             for (SequenceOutputFile so : inputFiles)
             {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/PicardAlignmentMetricsHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/PicardAlignmentMetricsHandler.java
@@ -141,7 +141,7 @@ public class PicardAlignmentMetricsHandler extends AbstractParameterizedOutputHa
 
             for (SequenceOutputFile o : inputs)
             {
-                Integer analysisId = o.getAnalysis_id();
+                Long analysisId = o.getAnalysis_id();
                 if (analysisId == null)
                 {
                     ctx.getJob().getLogger().warn("no analysis Id for file, attempting to find this job: " + o.getName());
@@ -150,7 +150,7 @@ public class PicardAlignmentMetricsHandler extends AbstractParameterizedOutputHa
                     TableSelector ts = new TableSelector(QueryService.get().getUserSchema(ctx.getJob().getUser(), ctx.getJob().getContainer(), SequenceAnalysisSchema.SCHEMA_NAME).getTable(SequenceAnalysisSchema.TABLE_ANALYSES), PageFlowUtil.set("rowid"), new SimpleFilter(FieldKey.fromString("runid/JobId"), sf.getRowId()), null);
                     if (ts.exists())
                     {
-                        analysisId = ts.getObject(Integer.class);
+                        analysisId = ts.getObject(Long.class);
                     }
                     else
                     {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/RecalculateSequenceMetricsHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/RecalculateSequenceMetricsHandler.java
@@ -81,7 +81,7 @@ public class RecalculateSequenceMetricsHandler extends AbstractParameterizedOutp
 
                 for (ReadData rd : rs.getReadData())
                 {
-                    for (Integer dataId : Arrays.asList(rd.getFileId1(), rd.getFileId2()))
+                    for (Long dataId : Arrays.asList(rd.getFileId1(), rd.getFileId2()))
                     {
                         if (dataId == null)
                         {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/model/AnalysisModelImpl.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/model/AnalysisModelImpl.java
@@ -27,7 +27,7 @@ import java.util.Date;
  */
 public class AnalysisModelImpl implements AnalysisModel
 {
-    private Integer _rowId;
+    private Long _rowId;
     private String _type;
     private Long _runId;
     private Integer _createdby;
@@ -35,7 +35,7 @@ public class AnalysisModelImpl implements AnalysisModel
     private Integer _modifiedby;
     private Date _modified;
     private String _container;
-    private Integer _readset;
+    private Long _readset;
     private Long _alignmentFile;
     private Long _reference_library;
     private Integer _library_id;
@@ -47,7 +47,7 @@ public class AnalysisModelImpl implements AnalysisModel
 
     }
 
-    public static AnalysisModelImpl getFromDb(int analysisId, User u)
+    public static AnalysisModelImpl getFromDb(long analysisId, User u)
     {
         if (PipelineJobService.get().getLocationType() != PipelineJobService.LocationType.WebServer)
         {
@@ -70,12 +70,12 @@ public class AnalysisModelImpl implements AnalysisModel
     }
 
     @Override
-    public Integer getAnalysisId()
+    public Long getAnalysisId()
     {
         return _rowId;
     }
 
-    public void setRowId(Integer rowId)
+    public void setRowId(Long rowId)
     {
         _rowId = rowId;
     }
@@ -105,7 +105,7 @@ public class AnalysisModelImpl implements AnalysisModel
         _container = container;
     }
 
-    public void setReadset(Integer readset)
+    public void setReadset(Long readset)
     {
         _readset = readset;
     }
@@ -149,7 +149,7 @@ public class AnalysisModelImpl implements AnalysisModel
     }
 
     @Override
-    public Integer getReadset()
+    public Long getReadset()
     {
         return _readset;
     }
@@ -265,7 +265,7 @@ public class AnalysisModelImpl implements AnalysisModel
     }
 
     @Override
-    public Integer getRowId()
+    public Long getRowId()
     {
         return _rowId;
     }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/model/AnalysisModelImpl.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/model/AnalysisModelImpl.java
@@ -29,15 +29,15 @@ public class AnalysisModelImpl implements AnalysisModel
 {
     private Integer _rowId;
     private String _type;
-    private Integer _runId;
+    private Long _runId;
     private Integer _createdby;
     private Date _created;
     private Integer _modifiedby;
     private Date _modified;
     private String _container;
     private Integer _readset;
-    private Integer _alignmentFile;
-    private Integer _reference_library;
+    private Long _alignmentFile;
+    private Long _reference_library;
     private Integer _library_id;
     private String _description;
     private String _synopsis;
@@ -85,7 +85,7 @@ public class AnalysisModelImpl implements AnalysisModel
         _type = type;
     }
 
-    public void setRunId(Integer runId)
+    public void setRunId(Long runId)
     {
         _runId = runId;
     }
@@ -110,18 +110,18 @@ public class AnalysisModelImpl implements AnalysisModel
         _readset = readset;
     }
 
-    public void setAlignmentFile(Integer alignmentFile)
+    public void setAlignmentFile(Long alignmentFile)
     {
         _alignmentFile = alignmentFile;
     }
 
-    public void setReference_library(Integer reference_library)
+    public void setReference_library(Long reference_library)
     {
         _reference_library = reference_library;
     }
 
     @Override
-    public void setReferenceLibrary(Integer reference_library)
+    public void setReferenceLibrary(Long reference_library)
 {
     _reference_library = reference_library;
 }
@@ -137,7 +137,7 @@ public class AnalysisModelImpl implements AnalysisModel
     }
 
     @Override
-    public Integer getRunId()
+    public Long getRunId()
     {
         return _runId;
     }
@@ -155,7 +155,7 @@ public class AnalysisModelImpl implements AnalysisModel
     }
 
     @Override
-    public Integer getAlignmentFile()
+    public Long getAlignmentFile()
     {
         return _alignmentFile;
     }
@@ -166,7 +166,7 @@ public class AnalysisModelImpl implements AnalysisModel
         return getData(_alignmentFile);
     }
 
-    private ExpData getData(Integer dataId)
+    private ExpData getData(Long dataId)
     {
         if (PipelineJobService.get().getLocationType() != PipelineJobService.LocationType.WebServer)
         {
@@ -194,12 +194,12 @@ public class AnalysisModelImpl implements AnalysisModel
     }
 
     @Override
-    public Integer getReferenceLibrary()
+    public Long getReferenceLibrary()
     {
         return _reference_library;
     }
 
-    public Integer getReference_Library()
+    public Long getReference_Library()
     {
         return _reference_library;
     }
@@ -208,7 +208,7 @@ public class AnalysisModelImpl implements AnalysisModel
     public ExpData getReferenceLibraryData(User u) throws PipelineJobException
     {
         //preferentially use library_id
-        Integer dataId = null;
+        Long dataId = null;
         if (_library_id != null && PipelineJobService.get().getLocationType() == PipelineJobService.LocationType.WebServer)
         {
             ReferenceGenome g = SequenceAnalysisService.get().getReferenceGenome(_library_id, u);
@@ -328,7 +328,7 @@ public class AnalysisModelImpl implements AnalysisModel
 //        return new TableSelector(SequenceAnalysisSchema.getTable(SequenceAnalysisSchema.TABLE_READSETS)).getObject(_readset, Readset.class);
 //    }
 
-    private String getFilePath(Integer dataId)
+    private String getFilePath(Long dataId)
     {
         if (dataId == null || PipelineJobService.get().getLocationType() != PipelineJobService.LocationType.WebServer)
         {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentAnalysisJob.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentAnalysisJob.java
@@ -37,8 +37,8 @@ public class AlignmentAnalysisJob extends SequenceJob
 {
     public static final String FOLDER_NAME = "sequenceAnalysis";
 
-    private int _analyisId;
-    private int _readsetId;
+    private long _analyisId;
+    private long _readsetId;
 
     // Default constructor for serialization
     protected AlignmentAnalysisJob()
@@ -79,7 +79,7 @@ public class AlignmentAnalysisJob extends SequenceJob
             Container targetContainer = c;
             if (submitJobToReadsetContainer)
             {
-                Integer readsetId = model.getReadset();
+                Long readsetId = model.getReadset();
                 if (readsetId != null)
                 {
                     SequenceReadsetImpl readset = SequenceAnalysisServiceImpl.get().getReadset(readsetId, u);
@@ -141,22 +141,22 @@ public class AlignmentAnalysisJob extends SequenceJob
         PipelineJobService.get().addTaskPipeline(settings);
     }
 
-    public int getAnalyisId()
+    public long getAnalyisId()
     {
         return _analyisId;
     }
 
-    public void setAnalyisId(int analyisId)
+    public void setAnalyisId(long analyisId)
     {
         _analyisId = analyisId;
     }
 
-    public int getReadsetId()
+    public long getReadsetId()
     {
         return _readsetId;
     }
 
-    public void setReadsetId(int readsetId)
+    public void setReadsetId(long readsetId)
     {
         _readsetId = readsetId;
     }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentAnalysisRemoteWorkTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentAnalysisRemoteWorkTask.java
@@ -92,9 +92,9 @@ public class AlignmentAnalysisRemoteWorkTask extends WorkDirectoryTask<Alignment
     {
         _taskHelper = new SequenceTaskHelper(getPipelineJob(), _wd);
 
-        Map<Integer, File> cachedFiles = getTaskHelper().getSequenceSupport().getAllCachedData();
+        Map<Long, File> cachedFiles = getTaskHelper().getSequenceSupport().getAllCachedData();
         getJob().getLogger().debug("total ExpDatas cached: " + cachedFiles.size());
-        for (Integer dataId : cachedFiles.keySet())
+        for (Long dataId : cachedFiles.keySet())
         {
             getJob().getLogger().debug("file was cached: " + dataId + " / " + cachedFiles.get(dataId).getPath());
         }
@@ -142,7 +142,7 @@ public class AlignmentAnalysisRemoteWorkTask extends WorkDirectoryTask<Alignment
     private File resolveRefFasta(AnalysisModel m, File inputBam) throws PipelineJobException
     {
         //first try to find FASTA based on reference_library
-        Integer refFastaId = m.getReferenceLibrary();
+        Long refFastaId = m.getReferenceLibrary();
         if (refFastaId != null)
         {
             File refFasta = getTaskHelper().getSequenceSupport().getCachedData(refFastaId);
@@ -184,7 +184,7 @@ public class AlignmentAnalysisRemoteWorkTask extends WorkDirectoryTask<Alignment
 
         for (AnalysisModel m : getTaskHelper().getSequenceSupport().getCachedAnalyses())
         {
-            int bamId = m.getAlignmentFile();
+            long bamId = m.getAlignmentFile();
             File bam = getTaskHelper().getSequenceSupport().getCachedData(bamId);
             if (bam != null)
             {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentImportTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentImportTask.java
@@ -187,7 +187,7 @@ public class AlignmentImportTask extends WorkDirectoryTask<AlignmentImportTask.F
 
             //process metrics
             Map<Long, Long> readsetToAnalysisMap = new LongHashMap<>();
-            Map<Long, Map<PipelineStepOutput.PicardMetricsOutput.TYPE, File>> typeMap = new HashMap<>();
+            Map<Long, Map<PipelineStepOutput.PicardMetricsOutput.TYPE, File>> typeMap = new LongHashMap<>();
             for (AnalysisModel model : ret)
             {
                 readsetToAnalysisMap.put(model.getReadset(), model.getRowId());

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentImportTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentImportTask.java
@@ -2,6 +2,7 @@ package org.labkey.sequenceanalysis.pipeline;
 
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONObject;
+import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.Table;
@@ -185,8 +186,8 @@ public class AlignmentImportTask extends WorkDirectoryTask<AlignmentImportTask.F
             transaction.commit();
 
             //process metrics
-            Map<Integer, Integer> readsetToAnalysisMap = new HashMap<>();
-            Map<Integer, Map<PipelineStepOutput.PicardMetricsOutput.TYPE, File>> typeMap = new HashMap<>();
+            Map<Long, Long> readsetToAnalysisMap = new LongHashMap<>();
+            Map<Long, Map<PipelineStepOutput.PicardMetricsOutput.TYPE, File>> typeMap = new HashMap<>();
             for (AnalysisModel model : ret)
             {
                 readsetToAnalysisMap.put(model.getReadset(), model.getRowId());

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentImportTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentImportTask.java
@@ -103,7 +103,7 @@ public class AlignmentImportTask extends WorkDirectoryTask<AlignmentImportTask.F
 
         //find moved BAM files and build map
         Map<String, ExpData> bamMap = new HashMap<>();
-        Integer runId = SequenceTaskHelper.getExpRunIdForJob(getJob());
+        Long runId = SequenceTaskHelper.getExpRunIdForJob(getJob());
         ExpRun run = ExperimentService.get().getExpRun(runId);
         List<? extends ExpData> datas = run.getInputDatas(SequenceAlignmentTask.FINAL_BAM_ROLE, ExpProtocol.ApplicationType.ExperimentRunOutput);
         if (!datas.isEmpty())
@@ -151,7 +151,7 @@ public class AlignmentImportTask extends WorkDirectoryTask<AlignmentImportTask.F
                     a.setLibrary_id(o.getInt("library_id"));
 
                     TableInfo ti = SequenceAnalysisSchema.getInstance().getSchema().getTable(SequenceAnalysisSchema.TABLE_REF_LIBRARIES);
-                    Integer refFastaId = new TableSelector(ti, PageFlowUtil.set("fasta_file")).getObject(o.getInt("library_id"), Integer.class);
+                    Long refFastaId = new TableSelector(ti, PageFlowUtil.set("fasta_file")).getObject(o.getInt("library_id"), Long.class);
                     a.setReferenceLibrary(refFastaId);
                     a.setContainer(getJob().getContainer().getId());
                     a.setCreated(new Date());

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/CacheGenomeTrigger.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/CacheGenomeTrigger.java
@@ -1,6 +1,7 @@
 package org.labkey.sequenceanalysis.pipeline;
 
 import org.apache.logging.log4j.Logger;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.pipeline.PipeRoot;
@@ -15,7 +16,6 @@ import org.labkey.api.sequenceanalysis.pipeline.SequencePipelineService;
 import org.labkey.sequenceanalysis.SequenceAnalysisModule;
 
 import java.io.File;
-import java.util.HashMap;
 import java.util.Map;
 
 public class CacheGenomeTrigger implements GenomeTrigger
@@ -48,7 +48,7 @@ public class CacheGenomeTrigger implements GenomeTrigger
     {
         try
         {
-            Map<Integer, File> genomeMap = new HashMap<>();
+            Map<Integer, File> genomeMap = new IntHashMap<>();
             ReferenceGenome rg = SequenceAnalysisService.get().getReferenceGenome(genomeId, u);
             genomeMap.put(rg.getGenomeId(), rg.getSourceFastaFile());
             cacheGenomes(c, u, genomeMap, log, false);

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/CreateReferenceLibraryTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/CreateReferenceLibraryTask.java
@@ -69,6 +69,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.labkey.api.exp.api.ExperimentService.asInteger;
+
 /**
  * User: bbimber
  * Date: 8/6/12
@@ -204,7 +206,7 @@ public class CreateReferenceLibraryTask extends PipelineJob.Task<CreateReference
                     throw errors;
                 }
                 libraryRow = new CaseInsensitiveHashMap<>(inserted.get(0));
-                rowId = (Integer) libraryRow.get("rowid");
+                rowId = asInteger(libraryRow.get("rowid"));
             }
             else
             {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/IlluminaFastqSplitter.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/IlluminaFastqSplitter.java
@@ -42,6 +42,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.zip.GZIPOutputStream;
 
+import static org.labkey.api.exp.api.ExperimentService.asLong;
+
 /**
  * This is designed to parse the FASTQ files produced by a single run on an illumina instructment and produce one gzipped FASTQ
  * for each sample in that run.  Parsing that CSV file to obtain the sample list is upstream of this class.
@@ -232,11 +234,11 @@ public class IlluminaFastqSplitter<SampleIdType>
         else
         {
             String suffix;
-            if (Integer.valueOf(0).equals(sampleId))
+            if (asLong(0L).equals(asLong(sampleId)))
             {
                 suffix = "Control";
             }
-            else if (sampleId == null || Integer.valueOf(-1).equals(sampleId))
+            else if (sampleId == null || asLong(-1L).equals(asLong(sampleId)))
             {
                 suffix = "Undetermined";
             }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/IlluminaImportTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/IlluminaImportTask.java
@@ -57,6 +57,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
+import static org.labkey.api.exp.api.ExperimentService.asInteger;
+
 /**
  * User: bbimber
  * Date: 4/22/12
@@ -292,7 +294,7 @@ public class IlluminaImportTask extends WorkDirectoryTask<IlluminaImportTask.Fac
 
         runRow = Table.insert(getJob().getUser(), runTable, runRow);
 
-        _instrumentRunId = (Integer)runRow.get("rowid");
+        _instrumentRunId = asInteger(runRow.get("rowid"));
         getJob().getLogger().info("Created run: " + _instrumentRunId);
     }
 

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/IlluminaImportTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/IlluminaImportTask.java
@@ -16,6 +16,7 @@
 package org.labkey.sequenceanalysis.pipeline;
 
 import au.com.bytecode.opencsv.CSVReader;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.biojava.nbio.core.exceptions.CompoundNotFoundException;
 import org.biojava.nbio.core.sequence.DNASequence;
@@ -142,18 +143,18 @@ public class IlluminaImportTask extends WorkDirectoryTask<IlluminaImportTask.Fac
             RecordedAction action = new RecordedAction(ACTION_NAME);
             action.addInputIfNotPresent(input, "Illumina Sample CSV");
 
-            Map<String, Integer> sampleMap = parseCsv(input, schema);
+            Map<String, Long> sampleMap = parseCsv(input, schema);
 
             //NOTE: it might be just as easy to match filename based on expected pattern
 
             //this step will be slow
-            IlluminaFastqSplitter<Integer> parser = new IlluminaFastqSplitter<>("Illumina", sampleMap, job.getLogger(), input.getParent(), prefix);
+            IlluminaFastqSplitter<Long> parser = new IlluminaFastqSplitter<>("Illumina", sampleMap, job.getLogger(), input.getParent(), prefix);
             parser.setOutputGzip(true);
             parser.setDestinationDir(getSupport().getAnalysisDirectory());
 
             // the first element of the pair is the sample ID.  the second is either 1 or 2,
             // depending on whether the file represents the forward or reverse reads
-            Map<Pair<Integer, Integer>, File> fileMap = parser.parseFastqFiles();
+            Map<Pair<Long, Integer>, File> fileMap = parser.parseFastqFiles();
 
             for (File f : parser.getFiles())
             {
@@ -164,7 +165,7 @@ public class IlluminaImportTask extends WorkDirectoryTask<IlluminaImportTask.Fac
 
             getJob().getLogger().info("Compressing FASTQ files");
             FileType gz = new FileType("gz");
-            for (Pair<Integer, Integer> sampleKey : fileMap.keySet())
+            for (Pair<Long, Integer> sampleKey : fileMap.keySet())
             {
                 File inputFile = fileMap.get(sampleKey);
                 if (!gz.isType(inputFile))
@@ -188,12 +189,12 @@ public class IlluminaImportTask extends WorkDirectoryTask<IlluminaImportTask.Fac
             Map<String, Object> row;
             for (Object key : new HashSet<>(sampleMap.values()))
             {
-                Integer readsetId = (Integer) key;
+                Long readsetId = (Long) key;
 
                 Readset readset = SequenceAnalysisService.get().getReadset(readsetId, getJob().getUser());
 
                 row = new HashMap<>();
-                Pair<Integer, Integer> pair = Pair.of(readsetId, 1);
+                Pair<Long, Integer> pair = Pair.of(readsetId, 1);
                 ReadDataImpl rd = new ReadDataImpl();
                 rd.setReadset(readsetId);
                 rd.setCreated(new Date());
@@ -295,7 +296,7 @@ public class IlluminaImportTask extends WorkDirectoryTask<IlluminaImportTask.Fac
         getJob().getLogger().info("Created run: " + _instrumentRunId);
     }
 
-    private void addQualityMetrics(DbSchema schema, int readsetId, Pair<Integer, Integer> key, IlluminaFastqSplitter parser, ExpData d)
+    private void addQualityMetrics(DbSchema schema, long readsetId, Pair<Long, Integer> key, IlluminaFastqSplitter parser, ExpData d)
     {
         getJob().getLogger().info("Adding quality metrics for file: " + d.getFile().getName());
         Map<Pair<Integer, Integer>, Integer> readCounts = parser.getReadCounts();
@@ -325,15 +326,15 @@ public class IlluminaImportTask extends WorkDirectoryTask<IlluminaImportTask.Fac
         return SequenceTaskHelper.createExpData(f, getJob());
     }
 
-    private Map<String, Integer> parseCsv(File sampleFile, DbSchema schema) throws PipelineJobException
+    private Map<String, Long> parseCsv(File sampleFile, DbSchema schema) throws PipelineJobException
     {
         getJob().getLogger().info("Parsing Sample File: " + sampleFile.getName());
         try (CSVReader reader = new CSVReader(Readers.getReader(sampleFile)))
         {
             //parse the samples file
             String [] nextLine;
-            Map<String, Integer> sampleMap = new HashMap<>();
-            sampleMap.put("S0", 0); //placeholder for control and unmapped reads
+            Map<String, Long> sampleMap = new HashMap<>();
+            sampleMap.put("S0", 0L); //placeholder for control and unmapped reads
 
             boolean inSamples = false;
             int sampleIdx = 0;
@@ -363,10 +364,10 @@ public class IlluminaImportTask extends WorkDirectoryTask<IlluminaImportTask.Fac
                     String indexesRC = new DNASequence(nextLine[6]).getReverseComplement().getSequenceAsString() + "+" + nextLine[8];
 
                     sampleIdx++;
-                    Integer readsetId;
+                    Long readsetId;
                     try
                     {
-                        readsetId = Integer.parseInt(nextLine[0]);
+                        readsetId = Long.parseLong(nextLine[0]);
                     }
                     catch (NumberFormatException e)
                     {
@@ -400,7 +401,7 @@ public class IlluminaImportTask extends WorkDirectoryTask<IlluminaImportTask.Fac
     }
 
     //not very efficient, but we only expect a handful of samples per run
-    private boolean validateReadsetId(Integer id) throws PipelineJobException, PipelineValidationException
+    private boolean validateReadsetId(Long id) throws PipelineJobException, PipelineValidationException
     {
         getJob().getLogger().debug("attempting to resolve readset by Id: " + id);
         if (id == null)
@@ -425,7 +426,7 @@ public class IlluminaImportTask extends WorkDirectoryTask<IlluminaImportTask.Fac
         return true;
     }
 
-    private Integer tryCreateReadset(DbSchema schema, String[] line) throws PipelineJobException
+    private Long tryCreateReadset(DbSchema schema, String[] line) throws PipelineJobException
     {
         if (!_settings.doAutoCreateReadsets())
             throw new PipelineJobException("Unable to find existing readset matching ID: " + line[0]);
@@ -462,7 +463,7 @@ public class IlluminaImportTask extends WorkDirectoryTask<IlluminaImportTask.Fac
         row.put("created", new Date());
 
         row = Table.insert(getJob().getUser(), rsTable, row);
-        return (Integer)row.get("rowid");
+        return MapUtils.getLong(row,"rowid");
     }
 
     private String resolveBarcode(String barcode)

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/IlluminaImportTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/IlluminaImportTask.java
@@ -182,7 +182,7 @@ public class IlluminaImportTask extends WorkDirectoryTask<IlluminaImportTask.Fac
             TableInfo rs = schema.getTable(SequenceAnalysisSchema.TABLE_READSETS);
             TableInfo readDataTable = schema.getTable(SequenceAnalysisSchema.TABLE_READ_DATA);
 
-            Integer runId = SequenceTaskHelper.getExpRunIdForJob(getJob(), false);
+            Long runId = SequenceTaskHelper.getExpRunIdForJob(getJob(), false);
 
             //update the readsets
             Map<String, Object> row;
@@ -453,7 +453,7 @@ public class IlluminaImportTask extends WorkDirectoryTask<IlluminaImportTask.Fac
         if (_instrumentRunId != null)
             row.put("instrument_run_id", _instrumentRunId);
 
-        Integer runId = SequenceTaskHelper.getExpRunIdForJob(getJob(), false);
+        Long runId = SequenceTaskHelper.getExpRunIdForJob(getJob(), false);
         if (runId != null)
             row.put("runid", runId);
 

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/IlluminaReadsetCreationTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/IlluminaReadsetCreationTask.java
@@ -87,7 +87,7 @@ public class IlluminaReadsetCreationTask extends WorkDirectoryTask<IlluminaReads
         PipelineJob job = getJob();
 
         job.getLogger().info("Updating readsets");
-        Integer runId = SequenceTaskHelper.getExpRunIdForJob(getJob());
+        Long runId = SequenceTaskHelper.getExpRunIdForJob(getJob());
 
         DbSchema schema = SequenceAnalysisSchema.getInstance().getSchema();
 
@@ -97,7 +97,7 @@ public class IlluminaReadsetCreationTask extends WorkDirectoryTask<IlluminaReads
             TableInfo readData = schema.getTable(SequenceAnalysisSchema.TABLE_READ_DATA);
 
             ExpRun run = ExperimentService.get().getExpRun(runId);
-            List<Integer> dataIds = new ArrayList<>();
+            List<Long> dataIds = new ArrayList<>();
             List<ExpData> outputs = run.getDataOutputs();
             for (ExpData d : outputs)
             {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ImportFastaSequencesTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ImportFastaSequencesTask.java
@@ -97,7 +97,7 @@ public class ImportFastaSequencesTask extends PipelineJob.Task<ImportFastaSequen
             List<Integer> sequenceIds = new ArrayList<>();
             for (File f : getPipelineJob().getFastas())
             {
-                Integer jobId = PipelineService.get().getJobId(getJob().getUser(), getJob().getContainer(), getJob().getJobGUID());
+                Long jobId = PipelineService.get().getJobId(getJob().getUser(), getJob().getContainer(), getJob().getJobGUID());
                 sequenceIds.addAll(SequenceAnalysisManager.get().importRefSequencesFromFasta(getJob().getContainer(), getJob().getUser(), f, getPipelineJob().isSplitWhitespace(), getPipelineJob().getParams(), getJob().getLogger(), getPipelineJob().getOutDir(), jobId));
             }
 

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ImportGenomeTrackTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ImportGenomeTrackTask.java
@@ -328,7 +328,7 @@ public class ImportGenomeTrackTask extends PipelineJob.Task<ImportGenomeTrackTas
         map.put("modified", new Date());
         map.put("modifiedby", getJob().getUser().getUserId());
         map.put("fileid", trackData.getRowId());
-        Integer jobId = PipelineService.get().getJobId(getJob().getUser(), genomeContainer, getJob().getJobGUID());
+        Long jobId = PipelineService.get().getJobId(getJob().getUser(), genomeContainer, getJob().getJobGUID());
         map.put("jobId", jobId);
 
         TableInfo trackTable = SequenceAnalysisSchema.getTable(SequenceAnalysisSchema.TABLE_LIBRARY_TRACKS);

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ImportGenomeTrackTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ImportGenomeTrackTask.java
@@ -81,6 +81,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.labkey.api.exp.api.ExperimentService.asInteger;
+
 /**
  * User: bbimber
  * Date: 8/6/12
@@ -338,7 +340,7 @@ public class ImportGenomeTrackTask extends PipelineJob.Task<ImportGenomeTrackTas
             throw new PipelineJobException("Unable to find rowid for new track");
         }
 
-        return (Integer)map.get("rowid");
+        return asInteger(map.get("rowid"));
     }
 
     private void sortGxf(File gxf) throws PipelineJobException

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/OrphanFilePipelineJob.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/OrphanFilePipelineJob.java
@@ -498,7 +498,7 @@ public class OrphanFilePipelineJob extends PipelineJob
             // NOTE: if this file is within a known job path, it still could be an orphan.  first check whether the directory has registered files.
             // If so, remove that path from the set of known job paths
             List<? extends ExpData> dataUnderPath = ExperimentService.get().getExpDatasUnderPath(dir, c);
-            Set<Integer> dataIdsUnderPath = new HashSet<>();
+            Set<Long> dataIdsUnderPath = new HashSet<>();
             for (ExpData d : dataUnderPath)
             {
                 dataIdsUnderPath.add(d.getRowId());

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ProcessVariantsHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ProcessVariantsHandler.java
@@ -609,7 +609,7 @@ public class ProcessVariantsHandler implements SequenceOutputHandler<SequenceOut
                 ReferenceGenome rg = ctx.getSequenceSupport().getCachedGenome(genomes.iterator().next());
                 MergeVcfsAndGenotypesWrapper cv = new MergeVcfsAndGenotypesWrapper(ctx.getLogger());
 
-                Map<Integer, Integer> fileMap = new HashMap<>();
+                Map<Integer, Long> fileMap = new HashMap<>();
                 inputFiles.forEach(x -> fileMap.put(x.getRowid(), x.getDataId()));
                 String[] ids = priorityOrder.split(",");
 
@@ -622,7 +622,7 @@ public class ProcessVariantsHandler implements SequenceOutputHandler<SequenceOut
                         throw new PipelineJobException("Unable to find file matching priority: " + i);
                     }
 
-                    int dataId = fileMap.get(i);
+                    long dataId = fileMap.get(i);
 
                     vcfsInPriority.add(ctx.getSequenceSupport().getCachedData(dataId));
                 }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ProcessVariantsHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ProcessVariantsHandler.java
@@ -171,7 +171,7 @@ public class ProcessVariantsHandler implements SequenceOutputHandler<SequenceOut
             throw new IllegalArgumentException("No library ID defined for VCFs");
         }
 
-        Set<Integer> readsetIds = new HashSet<>();
+        Set<Long> readsetIds = new HashSet<>();
         inputFiles.forEach(x -> readsetIds.add(x.getReadset()));
 
         int sampleCount;
@@ -676,7 +676,7 @@ public class ProcessVariantsHandler implements SequenceOutputHandler<SequenceOut
             _resumer.markComplete(ctx);
         }
 
-        private void processFile(File input, Integer libraryId, Integer readsetId, JobContext ctx) throws PipelineJobException
+        private void processFile(File input, Integer libraryId, Long readsetId, JobContext ctx) throws PipelineJobException
         {
             File processed = processVCF(input, libraryId, ctx, _resumer, true);
             if (processed != null && processed.exists())

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ProcessVariantsHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ProcessVariantsHandler.java
@@ -16,6 +16,9 @@ import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
+import org.labkey.api.collections.IntHashMap;
+import org.labkey.api.collections.IntHashSet;
+import org.labkey.api.collections.LongHashSet;
 import org.labkey.api.data.Container;
 import org.labkey.api.laboratory.DemographicsProvider;
 import org.labkey.api.module.Module;
@@ -160,7 +163,7 @@ public class ProcessVariantsHandler implements SequenceOutputHandler<SequenceOut
 
     public static SequenceOutputFile createSequenceOutput(PipelineJob job, File processed, List<SequenceOutputFile> inputFiles, String category)
     {
-        Set<Integer> libraryIds = new HashSet<>();
+        Set<Integer> libraryIds = new IntHashSet();
         inputFiles.forEach(x -> {
             if (x.getLibrary_id() != null)
                 libraryIds.add(x.getLibrary_id());
@@ -171,7 +174,7 @@ public class ProcessVariantsHandler implements SequenceOutputHandler<SequenceOut
             throw new IllegalArgumentException("No library ID defined for VCFs");
         }
 
-        Set<Long> readsetIds = new HashSet<>();
+        Set<Long> readsetIds = new LongHashSet();
         inputFiles.forEach(x -> readsetIds.add(x.getReadset()));
 
         int sampleCount;
@@ -598,7 +601,7 @@ public class ProcessVariantsHandler implements SequenceOutputHandler<SequenceOut
                     throw new PipelineJobException("Priority order not supplied for VCFs");
                 }
 
-                Set<Integer> genomes = new HashSet<>();
+                Set<Integer> genomes = new IntHashSet();
                 inputFiles.forEach(x -> genomes.add(x.getLibrary_id()));
 
                 if (genomes.size() != 1)
@@ -609,7 +612,7 @@ public class ProcessVariantsHandler implements SequenceOutputHandler<SequenceOut
                 ReferenceGenome rg = ctx.getSequenceSupport().getCachedGenome(genomes.iterator().next());
                 MergeVcfsAndGenotypesWrapper cv = new MergeVcfsAndGenotypesWrapper(ctx.getLogger());
 
-                Map<Integer, Long> fileMap = new HashMap<>();
+                Map<Integer, Long> fileMap = new IntHashMap<>();
                 inputFiles.forEach(x -> fileMap.put(x.getRowid(), x.getDataId()));
                 String[] ids = priorityOrder.split(",");
 

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ReadsetCreationTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ReadsetCreationTask.java
@@ -18,6 +18,8 @@ package org.labkey.sequenceanalysis.pipeline;
 import au.com.bytecode.opencsv.CSVReader;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.LongHashMap;
+import org.labkey.api.collections.LongHashSet;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbSchema;
@@ -62,7 +64,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -166,10 +167,10 @@ public class ReadsetCreationTask extends PipelineJob.Task<ReadsetCreationTask.Fa
 
         List<SequenceReadsetImpl> newReadsets = new ArrayList<>();
 
-        Set<Long> fileIdsWithExistingMetrics = new HashSet<>();
+        Set<Long> fileIdsWithExistingMetrics = new LongHashSet();
         try (DbScope.Transaction transaction = schema.getScope().ensureTransaction())
         {
-            Map<Long, String> readsetsToDeactivate = new HashMap<>();
+            Map<Long, String> readsetsToDeactivate = new LongHashMap<>();
             TableInfo readsetTable = schema.getTable(SequenceAnalysisSchema.TABLE_READSETS);
             TableInfo readDataTable = schema.getTable(SequenceAnalysisSchema.TABLE_READ_DATA);
 

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ReadsetCreationTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ReadsetCreationTask.java
@@ -156,7 +156,7 @@ public class ReadsetCreationTask extends PipelineJob.Task<ReadsetCreationTask.Fa
         SequencePipelineSettings settings = getSettings();
         DbSchema schema = SequenceAnalysisSchema.getInstance().getSchema();
 
-        Integer runId = SequenceTaskHelper.getExpRunIdForJob(getJob());
+        Long runId = SequenceTaskHelper.getExpRunIdForJob(getJob());
         ExpRun run = ExperimentService.get().getExpRun(runId);
         List<ExpData> datas = new ArrayList<>();
         datas.addAll(run.getInputDatas(SequenceTaskHelper.NORMALIZED_FASTQ_OUTPUTNAME, ExpProtocol.ApplicationType.ExperimentRunOutput));
@@ -166,7 +166,7 @@ public class ReadsetCreationTask extends PipelineJob.Task<ReadsetCreationTask.Fa
 
         List<SequenceReadsetImpl> newReadsets = new ArrayList<>();
 
-        Set<Integer> fileIdsWithExistingMetrics = new HashSet<>();
+        Set<Long> fileIdsWithExistingMetrics = new HashSet<>();
         try (DbScope.Transaction transaction = schema.getScope().ensureTransaction())
         {
             Map<Integer, String> readsetsToDeactivate = new HashMap<>();
@@ -514,7 +514,7 @@ public class ReadsetCreationTask extends PipelineJob.Task<ReadsetCreationTask.Fa
         }
     }
 
-    private void runFastqcForFile(Integer fileId) throws PipelineJobException
+    private void runFastqcForFile(Long fileId) throws PipelineJobException
     {
         ExpData d1 = ExperimentService.get().getExpData(fileId);
         if (d1 != null && d1.getFile().exists())
@@ -535,7 +535,7 @@ public class ReadsetCreationTask extends PipelineJob.Task<ReadsetCreationTask.Fa
         }
     }
 
-    private Long getTotalReadsForFile(int fileId, int readsetId)
+    private Long getTotalReadsForFile(long fileId, int readsetId)
     {
         TableInfo metricsTable = SequenceAnalysisManager.get().getTable(SequenceAnalysisSchema.TABLE_QUALITY_METRICS);
 
@@ -554,12 +554,12 @@ public class ReadsetCreationTask extends PipelineJob.Task<ReadsetCreationTask.Fa
         return 0L;
     }
 
-    public static long addQualityMetricsForReadset(Readset rs, int fileId, PipelineJob job) throws PipelineJobException
+    public static long addQualityMetricsForReadset(Readset rs, long fileId, PipelineJob job) throws PipelineJobException
     {
         return addQualityMetricsForReadset(rs, fileId, job, false);
     }
 
-    public static long addQualityMetricsForReadset(Readset rs, int fileId, PipelineJob job, boolean deleteExisting) throws PipelineJobException
+    public static long addQualityMetricsForReadset(Readset rs, long fileId, PipelineJob job, boolean deleteExisting) throws PipelineJobException
     {
         if (deleteExisting)
         {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ReadsetCreationTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ReadsetCreationTask.java
@@ -169,7 +169,7 @@ public class ReadsetCreationTask extends PipelineJob.Task<ReadsetCreationTask.Fa
         Set<Long> fileIdsWithExistingMetrics = new HashSet<>();
         try (DbScope.Transaction transaction = schema.getScope().ensureTransaction())
         {
-            Map<Integer, String> readsetsToDeactivate = new HashMap<>();
+            Map<Long, String> readsetsToDeactivate = new HashMap<>();
             TableInfo readsetTable = schema.getTable(SequenceAnalysisSchema.TABLE_READSETS);
             TableInfo readDataTable = schema.getTable(SequenceAnalysisSchema.TABLE_READ_DATA);
 
@@ -535,7 +535,7 @@ public class ReadsetCreationTask extends PipelineJob.Task<ReadsetCreationTask.Fa
         }
     }
 
-    private Long getTotalReadsForFile(long fileId, int readsetId)
+    private Long getTotalReadsForFile(long fileId, long readsetId)
     {
         TableInfo metricsTable = SequenceAnalysisManager.get().getTable(SequenceAnalysisSchema.TABLE_QUALITY_METRICS);
 

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ReferenceGenomeImpl.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ReferenceGenomeImpl.java
@@ -34,7 +34,7 @@ public class ReferenceGenomeImpl implements ReferenceGenome
     private File _sourceFasta;
     private File _workingFasta;
     private Integer _genomeId;
-    private Integer _expDataId;
+    private Long _expDataId;
 
     // Default constructor for serialization
     protected ReferenceGenomeImpl()
@@ -146,13 +146,13 @@ public class ReferenceGenomeImpl implements ReferenceGenome
         _genomeId = genomeId;
     }
 
-    public void setExpDataId(Integer expDataId)
+    public void setExpDataId(Long expDataId)
     {
         _expDataId = expDataId;
     }
 
     @Override
-    public Integer getFastaExpDataId()
+    public Long getFastaExpDataId()
     {
         return _expDataId;
     }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceAlignmentJob.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceAlignmentJob.java
@@ -38,7 +38,7 @@ public class SequenceAlignmentJob extends SequenceJob
 {
     public static final String FOLDER_NAME = "sequenceAnalysis";
 
-    private int _readsetId;
+    private long _readsetId;
 
     // Default constructor for serialization
     protected SequenceAlignmentJob()
@@ -112,7 +112,7 @@ public class SequenceAlignmentJob extends SequenceJob
         return ret;
     }
 
-    public int getReadsetId()
+    public long getReadsetId()
     {
         return _readsetId;
     }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceAlignmentTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceAlignmentTask.java
@@ -31,6 +31,7 @@ import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
+import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.data.ConvertHelper;
 import org.labkey.api.pipeline.ObjectKeySerialization;
 import org.labkey.api.pipeline.PairSerializer;
@@ -1282,7 +1283,7 @@ public class SequenceAlignmentTask extends WorkDirectoryTask<SequenceAlignmentTa
         {
             getJob().getLogger().info("No FASTQ merge necessary");
             List<Pair<File, File>> inputs = new ArrayList<>(files.values());
-            Optional<Integer> minReadData = files.keySet().stream().map(ReadData::getRowid).min(Integer::compareTo);
+            Optional<Long> minReadData = files.keySet().stream().map(ReadData::getRowid).min(Long::compareTo);
             return doAlignmentForSet(inputs, referenceGenome, rs, minReadData.get(), "", inputs.size() == 1 ? files.keySet().stream().iterator().next().getPlatformUnit() : null);
         }
     }
@@ -1340,7 +1341,7 @@ public class SequenceAlignmentTask extends WorkDirectoryTask<SequenceAlignmentTa
         return bam;
     }
 
-    public File doAlignmentForSet(List<Pair<File, File>> inputFiles, ReferenceGenome referenceGenome, Readset rs, int lowestReadDataId, @NotNull String msgSuffix, @Nullable String platformUnit) throws PipelineJobException, IOException
+    public File doAlignmentForSet(List<Pair<File, File>> inputFiles, ReferenceGenome referenceGenome, Readset rs, long lowestReadDataId, @NotNull String msgSuffix, @Nullable String platformUnit) throws PipelineJobException, IOException
     {
         AlignmentStep alignmentStep = getHelper().getSingleStep(AlignmentStep.class).create(getHelper());
 
@@ -1496,7 +1497,7 @@ public class SequenceAlignmentTask extends WorkDirectoryTask<SequenceAlignmentTa
         private boolean _alignmentMetricsDone = false;
         private File _renamedBamFile = null;
         private boolean _indexBamDone = false;
-        private Map<Integer, File> _readDataBamMap = new HashMap<>();
+        private Map<Long, File> _readDataBamMap = new LongHashMap<>();
 
         //for serialization
         public Resumer()
@@ -1795,12 +1796,12 @@ public class SequenceAlignmentTask extends WorkDirectoryTask<SequenceAlignmentTa
             saveState();
         }
 
-        public boolean isReadDataAlignmentDone(int readDataId)
+        public boolean isReadDataAlignmentDone(long readDataId)
         {
             return _readDataBamMap.containsKey(readDataId);
         }
 
-        public void setReadDataAlignmentDone(int readDataId, List<RecordedAction> actions, File bam) throws PipelineJobException
+        public void setReadDataAlignmentDone(long readDataId, List<RecordedAction> actions, File bam) throws PipelineJobException
         {
             getLogger().debug("setting read data alignment done: " + readDataId + ", " + (actions == null ? "0" : actions.size()) + " actions");
             _readDataBamMap.put(readDataId, bam);
@@ -1811,17 +1812,17 @@ public class SequenceAlignmentTask extends WorkDirectoryTask<SequenceAlignmentTa
             saveState();
         }
 
-        public File getBamForReadData(int readDataId)
+        public File getBamForReadData(long readDataId)
         {
             return _readDataBamMap.get(readDataId);
         }
 
-        public Map<Integer, File> getReadDataBamMap()
+        public Map<Long, File> getReadDataBamMap()
         {
             return _readDataBamMap;
         }
 
-        public void setReadDataBamMap(Map<Integer, File> readDataBamMap)
+        public void setReadDataBamMap(Map<Long, File> readDataBamMap)
         {
             _readDataBamMap = readDataBamMap;
         }
@@ -1874,8 +1875,8 @@ public class SequenceAlignmentTask extends WorkDirectoryTask<SequenceAlignmentTa
             ReadDataImpl rd = new ReadDataImpl();
             rd.setFile(file1, 1);
             rd.setFile(file2, 2);
-            rd.setReadset(-1);
-            rd.setRowid(-1);
+            rd.setReadset(-1L);
+            rd.setRowid(-1L);
             r._filesToAlign = new LinkedHashMap<>();
             r._filesToAlign.put(rd, pair);
 

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceAnalysisTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceAnalysisTask.java
@@ -159,7 +159,7 @@ public class SequenceAnalysisTask extends WorkDirectoryTask<SequenceAnalysisTask
         job.getLogger().info("Processing Alignments");
 
         //first validate all analysis records before actually creating any DB records
-        Integer runId = SequenceTaskHelper.getExpRunIdForJob(getJob());
+        Long runId = SequenceTaskHelper.getExpRunIdForJob(getJob());
         ExpRun run = ExperimentService.get().getExpRun(runId);
         AnalysisModelImpl analysisModel = null;
 
@@ -356,7 +356,7 @@ public class SequenceAnalysisTask extends WorkDirectoryTask<SequenceAnalysisTask
         return new RecordedActionSet();
     }
 
-    private void processAnalyses(AnalysisModelImpl analysisModel, int runId, List<RecordedAction> actions, SequenceTaskHelper taskHelper, boolean discardBam) throws PipelineJobException
+    private void processAnalyses(AnalysisModelImpl analysisModel, long runId, List<RecordedAction> actions, SequenceTaskHelper taskHelper, boolean discardBam) throws PipelineJobException
     {
         List<AnalysisStep.Output> outputs = new ArrayList<>();
         List<PipelineStepCtx<AnalysisStep>> steps = SequencePipelineService.get().getSteps(getJob(), AnalysisStep.class);

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceAnalysisTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceAnalysisTask.java
@@ -17,6 +17,7 @@ package org.labkey.sequenceanalysis.pipeline;
 
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
+import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
@@ -313,8 +314,8 @@ public class SequenceAnalysisTask extends WorkDirectoryTask<SequenceAnalysisTask
         if (SequenceTaskHelper.isAlignmentUsed(getJob()))
         {
             //build map used next to import metrics
-            Map<Integer, Integer> readsetToAnalysisMap = new HashMap<>();
-            Map<Integer, Map<PipelineStepOutput.PicardMetricsOutput.TYPE, File>> typeMap = new HashMap<>();
+            Map<Long, Long> readsetToAnalysisMap = new LongHashMap<>();
+            Map<Long, Map<PipelineStepOutput.PicardMetricsOutput.TYPE, File>> typeMap = new LongHashMap<>();
             readsetToAnalysisMap.put(analysisModel.getReadset(), analysisModel.getRowId());
             typeMap.put(analysisModel.getReadset(), new HashMap<>());
 

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceJob.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceJob.java
@@ -68,7 +68,7 @@ import java.util.stream.Collectors;
 public class SequenceJob extends PipelineJob implements FileAnalysisJobSupport, HasJobParams, SequenceOutputTracker
 {
     private TaskId _taskPipelineId;
-    private Integer _experimentRunRowId;
+    private Long _experimentRunRowId;
     private String _jobName;
     private String _description;
     private FileLike _webserverJobDir;
@@ -558,12 +558,12 @@ public class SequenceJob extends PipelineJob implements FileAnalysisJobSupport, 
         return _folderFileRoot;
     }
 
-    public Integer getExperimentRunRowId()
+    public Long getExperimentRunRowId()
     {
         return _experimentRunRowId;
     }
 
-    public void setExperimentRunRowId(Integer experimentRunRowId)
+    public void setExperimentRunRowId(Long experimentRunRowId)
     {
         _experimentRunRowId = experimentRunRowId;
     }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceJobSupportImpl.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceJobSupportImpl.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import htsjdk.samtools.util.IOUtil;
 import org.junit.Assert;
 import org.junit.Test;
+import org.labkey.api.collections.IntHashMap;
+import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.pipeline.PipelineJob;
@@ -37,10 +39,10 @@ import java.util.Map;
  */
 public class SequenceJobSupportImpl implements SequenceAnalysisJobSupport, Serializable
 {
-    private final Map<Long, File> _cachedFilePaths = new HashMap<>();
+    private final Map<Long, File> _cachedFilePaths = new LongHashMap<>();
     private final List<SequenceReadsetImpl> _cachedReadsets = new ArrayList<>();
-    private final Map<Integer, AnalysisModel> _cachedAnalyses = new HashMap<>();
-    private final Map<Integer, ReferenceGenome> _cachedGenomes = new HashMap<>();
+    private final Map<Long, AnalysisModel> _cachedAnalyses = new LongHashMap<>();
+    private final Map<Integer, ReferenceGenome> _cachedGenomes = new IntHashMap<>();
     private final Map<String, Serializable> _cachedObjects = new HashMap<>();
 
     private transient boolean _modifiedSinceSerialize = false;
@@ -53,7 +55,7 @@ public class SequenceJobSupportImpl implements SequenceAnalysisJobSupport, Seria
     }
 
     @Override
-    public SequenceReadsetImpl getCachedReadset(Integer rowId)
+    public SequenceReadsetImpl getCachedReadset(Long rowId)
     {
         if (rowId == null || rowId < 1)
         {
@@ -72,19 +74,19 @@ public class SequenceJobSupportImpl implements SequenceAnalysisJobSupport, Seria
     }
 
     @Override
-    public AnalysisModel getCachedAnalysis(int rowId)
+    public AnalysisModel getCachedAnalysis(long rowId)
     {
         return _cachedAnalyses.get(rowId);
     }
 
     @Override
-    public void cacheReadset(int readsetId, User u)
+    public void cacheReadset(long readsetId, User u)
     {
         cacheReadset(readsetId,u, false);
     }
 
     @Override
-    public void cacheReadset(int readsetId, User u, boolean allowReadsetsWithArchivedData)
+    public void cacheReadset(long readsetId, User u, boolean allowReadsetsWithArchivedData)
     {
         SequenceReadsetImpl rs = SequenceAnalysisServiceImpl.get().getReadset(readsetId, u);
         if (rs != null)
@@ -303,7 +305,7 @@ public class SequenceJobSupportImpl implements SequenceAnalysisJobSupport, Seria
         public void testSerializeWithMap() throws Exception
         {
             SequenceJobSupportImpl js1 = new SequenceJobSupportImpl();
-            js1._cachedAnalyses.put(1, new AnalysisModelImpl());
+            js1._cachedAnalyses.put(1L, new AnalysisModelImpl());
             js1._cachedGenomes.put(2, new ReferenceGenomeImpl());
             SequenceReadsetImpl rs1 = new SequenceReadsetImpl();
             rs1.setRowId(100);
@@ -324,13 +326,13 @@ public class SequenceJobSupportImpl implements SequenceAnalysisJobSupport, Seria
             mapper.writeValue(writer, js1);
 
             SequenceJobSupportImpl deserialized = mapper.readValue(new StringReader(writer.toString()), SequenceJobSupportImpl.class);
-            assertNotNull("Analysis map not serialized properly", deserialized._cachedAnalyses.get(1));
+            assertNotNull("Analysis map not serialized properly", deserialized._cachedAnalyses.get(1L));
             assertNotNull("Genome map not serialized properly", deserialized._cachedGenomes.get(2));
             assertEquals("Readset list not serialized properly", 1, deserialized._cachedReadsets.size());
             assertEquals("Readset not deserialized with correct rowid", 100, deserialized._cachedReadsets.get(0).getRowId());
             assertEquals("Readset not deserialized with correct readsetid", 100, deserialized._cachedReadsets.get(0).getReadsetId().intValue());
 
-            assertNotNull("File map not serialized properly", deserialized._cachedFilePaths.get(4));
+            assertNotNull("File map not serialized properly", deserialized._cachedFilePaths.get(4L));
             assertNotNull("Cached map not serialized properly", deserialized.getCachedObject("cachedMap",Map.class));
             assertEquals(" Cached int not serialized properly", Integer.valueOf(1), deserialized.getCachedObject("cachedInt", Integer.class));
             assertEquals(" Cached string not serialized properly", "foo", deserialized.getCachedObject("cachedString", String.class));

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceJobSupportImpl.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceJobSupportImpl.java
@@ -37,7 +37,7 @@ import java.util.Map;
  */
 public class SequenceJobSupportImpl implements SequenceAnalysisJobSupport, Serializable
 {
-    private final Map<Integer, File> _cachedFilePaths = new HashMap<>();
+    private final Map<Long, File> _cachedFilePaths = new HashMap<>();
     private final List<SequenceReadsetImpl> _cachedReadsets = new ArrayList<>();
     private final Map<Integer, AnalysisModel> _cachedAnalyses = new HashMap<>();
     private final Map<Integer, ReferenceGenome> _cachedGenomes = new HashMap<>();
@@ -243,13 +243,13 @@ public class SequenceJobSupportImpl implements SequenceAnalysisJobSupport, Seria
     }
 
     @Override
-    public File getCachedData(int dataId)
+    public File getCachedData(long dataId)
     {
         return _cachedFilePaths.get(dataId);
     }
 
     @Override
-    public Map<Integer, File> getAllCachedData()
+    public Map<Long, File> getAllCachedData()
     {
         return Collections.unmodifiableMap(_cachedFilePaths);
     }
@@ -309,7 +309,7 @@ public class SequenceJobSupportImpl implements SequenceAnalysisJobSupport, Seria
             rs1.setRowId(100);
 
             js1._cachedReadsets.add(rs1);
-            js1._cachedFilePaths.put(4, new File("/"));
+            js1._cachedFilePaths.put(4L, new File("/"));
 
             HashMap<Integer, Integer> map = new HashMap<>();
             map.put(1, 1);

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceOutputHandlerFinalTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceOutputHandlerFinalTask.java
@@ -87,7 +87,7 @@ public class SequenceOutputHandlerFinalTask extends PipelineJob.Task<SequenceOut
     @Override
     public RecordedActionSet run() throws PipelineJobException
     {
-        Integer runId = SequenceTaskHelper.getExpRunIdForJob(getJob());
+        Long runId = SequenceTaskHelper.getExpRunIdForJob(getJob());
         getPipelineJob().setExperimentRunRowId(runId);
 
         //create analysisRecord
@@ -164,7 +164,7 @@ public class SequenceOutputHandlerFinalTask extends PipelineJob.Task<SequenceOut
         return new RecordedActionSet();
     }
 
-    public static Set<SequenceOutputFile> createOutputFiles(SequenceJob job, int runId, @Nullable Integer analysisId)
+    public static Set<SequenceOutputFile> createOutputFiles(SequenceJob job, long runId, @Nullable Integer analysisId)
     {
         job.getLogger().info("creating " + job.getOutputsToCreate().size() + " new output files for run: " + runId);
 
@@ -205,7 +205,7 @@ public class SequenceOutputHandlerFinalTask extends PipelineJob.Task<SequenceOut
         return created;
     }
 
-    public static void updateOutputFile(SequenceOutputFile o, PipelineJob job, Integer runId, Integer analysisId)
+    public static void updateOutputFile(SequenceOutputFile o, PipelineJob job, Long runId, Integer analysisId)
     {
         o.setRunId(runId);
         o.setAnalysis_id(analysisId);

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceOutputHandlerFinalTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceOutputHandlerFinalTask.java
@@ -119,7 +119,7 @@ public class SequenceOutputHandlerFinalTask extends PipelineJob.Task<SequenceOut
         am.setType(getPipelineJob().getHandler().getAnalysisType(getJob()));
         TableInfo analysisTable = SequenceAnalysisSchema.getTable(SequenceAnalysisSchema.TABLE_ANALYSES);
 
-        Set<Integer> readsetIds = new HashSet<>();
+        Set<Long> readsetIds = new HashSet<>();
         for (SequenceOutputFile so : getPipelineJob().getFiles())
         {
             if (so.getReadset() == null)
@@ -137,7 +137,7 @@ public class SequenceOutputHandlerFinalTask extends PipelineJob.Task<SequenceOut
         }
 
         Table.insert(getJob().getUser(), analysisTable, am);
-        int analysisId = am.getRowId();
+        long analysisId = am.getRowId();
 
         List<SequenceOutputFile> outputsCreated = new ArrayList<>();
         if (!getPipelineJob().getOutputsToCreate().isEmpty())
@@ -164,7 +164,7 @@ public class SequenceOutputHandlerFinalTask extends PipelineJob.Task<SequenceOut
         return new RecordedActionSet();
     }
 
-    public static Set<SequenceOutputFile> createOutputFiles(SequenceJob job, long runId, @Nullable Integer analysisId)
+    public static Set<SequenceOutputFile> createOutputFiles(SequenceJob job, long runId, @Nullable Long analysisId)
     {
         job.getLogger().info("creating " + job.getOutputsToCreate().size() + " new output files for run: " + runId);
 
@@ -205,7 +205,7 @@ public class SequenceOutputHandlerFinalTask extends PipelineJob.Task<SequenceOut
         return created;
     }
 
-    public static void updateOutputFile(SequenceOutputFile o, PipelineJob job, Long runId, Integer analysisId)
+    public static void updateOutputFile(SequenceOutputFile o, PipelineJob job, Long runId, Long analysisId)
     {
         o.setRunId(runId);
         o.setAnalysis_id(analysisId);

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceReadsetHandlerFinalTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceReadsetHandlerFinalTask.java
@@ -71,7 +71,7 @@ public class SequenceReadsetHandlerFinalTask extends PipelineJob.Task<SequenceRe
     @Override
     public RecordedActionSet run() throws PipelineJobException
     {
-        Integer runId = SequenceTaskHelper.getExpRunIdForJob(getJob());
+        Long runId = SequenceTaskHelper.getExpRunIdForJob(getJob());
         getPipelineJob().setExperimentRunRowId(runId);
 
         List<SequenceOutputFile> outputsCreated = new ArrayList<>();

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceReadsetHandlerJob.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceReadsetHandlerJob.java
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 public class SequenceReadsetHandlerJob extends SequenceJob implements HasJobParams
 {
     private String _handlerClassName;
-    private List<Integer> _readsetIds;
+    private List<Long> _readsetIds;
 
     // Default constructor for serialization
     protected SequenceReadsetHandlerJob()
@@ -105,12 +105,12 @@ public class SequenceReadsetHandlerJob extends SequenceJob implements HasJobPara
         return null;
     }
 
-    public List<Integer> getReadsetIds()
+    public List<Long> getReadsetIds()
     {
         return _readsetIds;
     }
 
-    public void setReadsetIds(List<Integer> readsetIds)
+    public void setReadsetIds(List<Long> readsetIds)
     {
         _readsetIds = readsetIds;
     }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceTaskHelper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceTaskHelper.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.sequenceanalysis.pipeline;
 
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
@@ -182,15 +183,15 @@ public class SequenceTaskHelper implements PipelineContext
         return _settings;
     }
 
-    public static Integer getExpRunIdForJob(PipelineJob job) throws PipelineJobException
+    public static Long getExpRunIdForJob(PipelineJob job) throws PipelineJobException
     {
         return getExpRunIdForJob(job, true);
     }
 
-    public static Integer getExpRunIdForJob(PipelineJob job, boolean throwUnlessFound) throws PipelineJobException
+    public static Long getExpRunIdForJob(PipelineJob job, boolean throwUnlessFound) throws PipelineJobException
     {
-        Integer jobId = PipelineService.get().getJobId(job.getUser(), job.getContainer(), job.getJobGUID());
-        Integer parentJobId = PipelineService.get().getJobId(job.getUser(), job.getContainer(), job.getParentGUID());
+        Long jobId = PipelineService.get().getJobId(job.getUser(), job.getContainer(), job.getJobGUID());
+        Long parentJobId = PipelineService.get().getJobId(job.getUser(), job.getContainer(), job.getParentGUID());
 
         TableInfo runs = ExperimentService.get().getSchema().getTable("ExperimentRun");
         TableSelector ts = new TableSelector(runs, Collections.singleton("RowId"), new SimpleFilter(FieldKey.fromString("JobId"), jobId), null);
@@ -210,7 +211,7 @@ public class SequenceTaskHelper implements PipelineContext
                 return null;
         }
         Map<String, Object> row = rows[0];
-        return (Integer)row.get("rowid");
+        return MapUtils.getLong(row,"rowid");
     }
 
     public static String getUnzippedBaseName(File file)

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceTaskHelper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceTaskHelper.java
@@ -15,7 +15,7 @@
  */
 package org.labkey.sequenceanalysis.pipeline;
 
-import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/TaskFileManagerImpl.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/TaskFileManagerImpl.java
@@ -574,7 +574,7 @@ public class TaskFileManagerImpl implements TaskFileManager, Serializable
                     toInsert.put("createdby", _job.getUser().getUserId());
                     toInsert.put("created", new Date());
 
-                    Integer readsetId = Integer.parseInt(line[0]);
+                    Long readsetId = Long.parseLong(line[0]);
                     toInsert.put("readset", readsetId);
                     if (readsetMap.containsKey(readsetId))
                     {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/TaskFileManagerImpl.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/TaskFileManagerImpl.java
@@ -361,7 +361,7 @@ public class TaskFileManagerImpl implements TaskFileManager, Serializable
     {
         if (!_job.getOutputsToCreate().isEmpty())
         {
-            Integer runId = SequenceTaskHelper.getExpRunIdForJob(_job);
+            Long runId = SequenceTaskHelper.getExpRunIdForJob(_job);
             return SequenceOutputHandlerFinalTask.createOutputFiles(_job, runId, analysisId);
         }
         else
@@ -582,7 +582,7 @@ public class TaskFileManagerImpl implements TaskFileManager, Serializable
                     }
 
                     String type = StringUtils.trimToNull(line[2]);
-                    Integer dataId = null;
+                    Long dataId = null;
                     if (typeMap.containsKey(readsetId) && type != null)
                     {
                         _job.getLogger().debug("importing metrics using readsetId");

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/TaskFileManagerImpl.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/TaskFileManagerImpl.java
@@ -116,7 +116,7 @@ public class TaskFileManagerImpl implements TaskFileManager, Serializable
     }
 
     @Override
-    public void addSequenceOutput(File file, String label, String category, @Nullable Integer readsetId, @Nullable Integer analysisId, @Nullable Integer genomeId, @Nullable String description)
+    public void addSequenceOutput(File file, String label, String category, @Nullable Long readsetId, @Nullable Long analysisId, @Nullable Integer genomeId, @Nullable String description)
     {
         SequenceOutputFile so = new SequenceOutputFile();
         so.setFile(file);
@@ -357,7 +357,7 @@ public class TaskFileManagerImpl implements TaskFileManager, Serializable
     }
 
     @Override
-    public Set<SequenceOutputFile> createSequenceOutputRecords(@Nullable Integer analysisId) throws PipelineJobException
+    public Set<SequenceOutputFile> createSequenceOutputRecords(@Nullable Long analysisId) throws PipelineJobException
     {
         if (!_job.getOutputsToCreate().isEmpty())
         {
@@ -539,7 +539,7 @@ public class TaskFileManagerImpl implements TaskFileManager, Serializable
     }
 
     @Override
-    public void writeMetricsToDb(Map<Integer, Integer> readsetMap, Map<Integer, Map<PipelineStepOutput.PicardMetricsOutput.TYPE, File>> typeMap) throws PipelineJobException
+    public void writeMetricsToDb(Map<Long, Long> readsetMap, Map<Long, Map<PipelineStepOutput.PicardMetricsOutput.TYPE, File>> typeMap) throws PipelineJobException
     {
         if (PipelineJobService.get().getLocationType() != PipelineJobService.LocationType.WebServer)
         {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/query/SequenceTriggerHelper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/query/SequenceTriggerHelper.java
@@ -13,6 +13,7 @@ import org.biojava.nbio.core.sequence.template.Sequence;
 import org.biojava.nbio.core.sequence.transcription.TranscriptionEngine;
 import org.junit.Assert;
 import org.junit.Test;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.SimpleFilter;
@@ -34,7 +35,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -50,7 +50,7 @@ public class SequenceTriggerHelper
 
     private static final TranscriptionEngine _engine = new TranscriptionEngine.Builder().dnaCompounds(AmbiguityDNACompoundSet.getDNACompoundSet()).rnaCompounds(AmbiguityRNACompoundSet.getRNACompoundSet()).initMet(false).trimStop(false).build();
 
-    private final Map<Integer, String> _sequenceMap = new HashMap<>();
+    private final Map<Integer, String> _sequenceMap = new IntHashMap<>();
 
     public SequenceTriggerHelper(int userId, String containerId)
     {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/query/SequenceTriggerHelper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/query/SequenceTriggerHelper.java
@@ -228,7 +228,7 @@ public class SequenceTriggerHelper
         }
     }
     
-    public int createExpData(String relPath) {
+    public long createExpData(String relPath) {
         PipeRoot pr = PipelineService.get().getPipelineRootSetting(getContainer());
         if (pr == null)
         {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/BamHaplotyper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/BamHaplotyper.java
@@ -13,6 +13,8 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.labkey.api.collections.IntHashMap;
+import org.labkey.api.collections.StringHashMap;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
@@ -37,7 +39,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -119,7 +120,7 @@ public class BamHaplotyper
 
                     if (!found)
                     {
-                        Map<Integer, Integer> map = new HashMap<>();
+                        Map<Integer, Integer> map = new IntHashMap<>();
                         map.put(so.getRowid(), newPair.second);
                         combinedResults.add(Pair.of(newPair.first, map));
                     }
@@ -162,7 +163,7 @@ public class BamHaplotyper
     private Map<Integer, TreeSet<Integer>> getInsertionMap(List<Pair<Character[][], Map<Integer, Integer>>> combinedResults)
     {
         //build list of all insertions that are present
-        Map<Integer, TreeSet<Integer>> indels = new HashMap<>();
+        Map<Integer, TreeSet<Integer>> indels = new IntHashMap<>();
         for (Pair<Character[][], Map<Integer, Integer>> pair : combinedResults)
         {
             for (int idx = 0;idx < pair.first.length;idx++)
@@ -189,7 +190,7 @@ public class BamHaplotyper
     private Map<String, Map<Integer, Integer>> convertResults(List<Pair<Character[][], Map<Integer, Integer>>> combinedResults, byte[] refBases, Map<Integer, TreeSet<Integer>> indels)
     {
         //now iterate each array, convert to string and return results
-        Map<String, Map<Integer, Integer>> ret = new HashMap<>();
+        Map<String, Map<Integer, Integer>> ret = new StringHashMap<>();
         for (Pair<Character[][], Map<Integer, Integer>> pair : combinedResults)
         {
             StringBuilder sb = new StringBuilder();

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/RestoreSraDataHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/RestoreSraDataHandler.java
@@ -309,14 +309,15 @@ public class RestoreSraDataHandler extends AbstractParameterizedOutputHandler<Se
                     if (!hasMetrics)
                     {
                         job.getLogger().debug("No existing metrics found for: " + rd.getFileId1());
-                        List<Integer> toAdd = new ArrayList<>(rd.getFileId1());
+                        List<Long> toAdd = new ArrayList<>();
+                        toAdd.add(rd.getFileId1());
                         if (rd.getFileId2() != null)
                         {
                             toAdd.add(rd.getFileId2());
                         }
 
                         job.getLogger().debug("adding metrics for " + toAdd.size() + " total fastq files");
-                        for (int dataId : toAdd)
+                        for (long dataId : toAdd)
                         {
                             //then delete/add:
                             job.getLogger().debug("adding metrics for: " + dataId);

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/AASnpByCodonAggregator.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/AASnpByCodonAggregator.java
@@ -18,6 +18,7 @@ package org.labkey.sequenceanalysis.run.analysis;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.reference.ReferenceSequence;
 import org.apache.logging.log4j.Logger;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.SimpleFilter;
@@ -76,7 +77,7 @@ public class AASnpByCodonAggregator extends NtSnpByPosAggregator
         assert ref != null;
         _refSequenceMap.put(ref.getName(), ref.getBases());
 
-        Map<Integer, List<NTSnp>> highQualitySnpsByPos = new HashMap<>();
+        Map<Integer, List<NTSnp>> highQualitySnpsByPos = new IntHashMap<>();
 
         for (Integer pos : snps.keySet())
         {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/AASnpByReadAggregator.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/AASnpByReadAggregator.java
@@ -3,6 +3,7 @@ package org.labkey.sequenceanalysis.run.analysis;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.reference.ReferenceSequence;
 import org.apache.logging.log4j.Logger;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.security.User;
@@ -51,7 +52,7 @@ public class AASnpByReadAggregator extends AASnpByCodonAggregator
         if (!_refSequenceMap.containsKey(ref.getName()));
             _refSequenceMap.put(ref.getName(), ref.getBases());
 
-        Map<Integer, List<NTSnp>> highQualitySnpsByPos = new HashMap<>();
+        Map<Integer, List<NTSnp>> highQualitySnpsByPos = new IntHashMap<>();
 
         for (Integer pos : snps.keySet())
         {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/AbstractAlignmentAggregator.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/AbstractAlignmentAggregator.java
@@ -19,6 +19,7 @@ import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.reference.ReferenceSequence;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.ReferenceLibraryHelper;
 import org.labkey.sequenceanalysis.run.util.AASnp;
@@ -230,7 +231,7 @@ abstract public class AbstractAlignmentAggregator implements AlignmentAggregator
         return ref;
     }
 
-    private final Map<Integer, Map<Integer, Map<String, Double>>> _qualMap = new HashMap<>();
+    private final Map<Integer, Map<Integer, Map<String, Double>>> _qualMap = new IntHashMap<>();
 
     private Map<Integer, Map<String, Double>> getQualsForReference(Integer refId) throws PipelineJobException
     {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/AvgBaseQualityAggregator.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/AvgBaseQualityAggregator.java
@@ -25,6 +25,8 @@ import htsjdk.samtools.util.Interval;
 import htsjdk.samtools.util.IntervalList;
 import htsjdk.samtools.util.SamLocusIterator;
 import org.apache.logging.log4j.Logger;
+import org.labkey.api.collections.IntHashMap;
+import org.labkey.api.collections.StringHashMap;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.sequenceanalysis.util.SequenceUtil;
 
@@ -93,7 +95,7 @@ public class AvgBaseQualityAggregator
             if (sr == null)
                 throw new IllegalArgumentException("Unknown reference: " + refName);
 
-            Map<Integer, Map<String, Double>> quals = new HashMap<>();
+            Map<Integer, Map<String, Double>> quals = new IntHashMap<>();
             IntervalList il = new IntervalList(header);
             il.add(new Interval(refName, start, stop));
             quals.put(sr.getSequenceIndex(), calculateAvgQualsForInterval(reader, il));
@@ -115,7 +117,7 @@ public class AvgBaseQualityAggregator
             SAMFileHeader header = reader.getFileHeader();
             List<SAMSequenceRecord> sequences = header.getSequenceDictionary().getSequences();
 
-            Map<Integer, Map<String, Double>> quals = new HashMap<>();
+            Map<Integer, Map<String, Double>> quals = new IntHashMap<>();
             for(SAMSequenceRecord sr : sequences) {
                 IntervalList il = new IntervalList(header);
                 il.add(new Interval(sr.getSequenceName(), 1, sr.getSequenceLength()));
@@ -136,7 +138,7 @@ public class AvgBaseQualityAggregator
      */
     private Map<String, Double> calculateAvgQualsForInterval(SamReader sam, IntervalList il)
     {
-        Map<String, Double> quals = new HashMap<>();
+        Map<String, Double> quals = new StringHashMap<>();
 
         try (SamLocusIterator sli = new SamLocusIterator(sam, il, true))
         {
@@ -210,7 +212,7 @@ public class AvgBaseQualityAggregator
         if (map == null)
             return null;
 
-        Map<Integer, Map<String, Double>> ret = new HashMap<>();
+        Map<Integer, Map<String, Double>> ret = new IntHashMap<>();
         for (String key : map.keySet())
         {
             String[] tokens = key.split("\\|\\|");

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/MergeLoFreqVcfHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/MergeLoFreqVcfHandler.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
+import org.labkey.api.collections.LongHashSet;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.pipeline.PipelineJobException;
@@ -183,7 +184,7 @@ public class MergeLoFreqVcfHandler extends AbstractParameterizedOutputHandler<Se
             {
                 writer.writeNext(new String[]{"ReadsetName", "OutputFileId", "ReadsetId", "Source", "Contig", "Start", "End", "Length", "Ref", "AltAllele", "GatkDepth", "LoFreqDepth", "AltCount", "AltAF"});
 
-                Set<Integer> analysesWithoutPindel = new HashSet<>();
+                Set<Long> analysesWithoutPindel = new LongHashSet();
                 for (SequenceOutputFile so : inputFiles)
                 {
                     //This will error if the coverage file is not found.  Perform check now to fail fast

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/NextCladeHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/NextCladeHandler.java
@@ -94,7 +94,7 @@ public class NextCladeHandler extends AbstractParameterizedOutputHandler<Sequenc
         @Override
         public void complete(JobContext ctx, List<SequenceOutputFile> inputFiles, List<SequenceOutputFile> outputsCreated) throws PipelineJobException
         {
-            Map<Integer, SequenceOutputFile> readsetToInput = inputFiles.stream().collect(Collectors.toMap(SequenceOutputFile::getReadset, x -> x));
+            Map<Long, SequenceOutputFile> readsetToInput = inputFiles.stream().collect(Collectors.toMap(SequenceOutputFile::getReadset, x -> x));
 
             ctx.getJob().getLogger().info("Parsing NextClade JSON:");
             for (SequenceOutputFile so : outputsCreated)
@@ -176,7 +176,7 @@ public class NextCladeHandler extends AbstractParameterizedOutputHandler<Sequenc
         }
     }
 
-    public static void processAndImportNextCladeAa(PipelineJob job, File jsonFile, int analysisId, int libraryId, long alignmentId, int readsetId, File consensusVCF, boolean dbImport) throws PipelineJobException
+    public static void processAndImportNextCladeAa(PipelineJob job, File jsonFile, long analysisId, int libraryId, long alignmentId, long readsetId, File consensusVCF, boolean dbImport) throws PipelineJobException
     {
         JSONObject sample = parseNextClade(jsonFile, job.getLogger());
         if (sample == null)
@@ -360,7 +360,7 @@ public class NextCladeHandler extends AbstractParameterizedOutputHandler<Sequenc
         }
     }
 
-    private static void saveClade(String clade, int analysisId, long alignmentId, int readsetId, PipelineJob job) throws PipelineJobException
+    private static void saveClade(String clade, long analysisId, long alignmentId, long readsetId, PipelineJob job) throws PipelineJobException
     {
         List<Map<String, Object>> toInsert = new ArrayList<>();
         Map<String, Object> row1 = new CaseInsensitiveHashMap<>();

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/NextCladeHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/NextCladeHandler.java
@@ -176,7 +176,7 @@ public class NextCladeHandler extends AbstractParameterizedOutputHandler<Sequenc
         }
     }
 
-    public static void processAndImportNextCladeAa(PipelineJob job, File jsonFile, int analysisId, int libraryId, int alignmentId, int readsetId, File consensusVCF, boolean dbImport) throws PipelineJobException
+    public static void processAndImportNextCladeAa(PipelineJob job, File jsonFile, int analysisId, int libraryId, long alignmentId, int readsetId, File consensusVCF, boolean dbImport) throws PipelineJobException
     {
         JSONObject sample = parseNextClade(jsonFile, job.getLogger());
         if (sample == null)
@@ -360,7 +360,7 @@ public class NextCladeHandler extends AbstractParameterizedOutputHandler<Sequenc
         }
     }
 
-    private static void saveClade(String clade, int analysisId, int alignmentId, int readsetId, PipelineJob job) throws PipelineJobException
+    private static void saveClade(String clade, int analysisId, long alignmentId, int readsetId, PipelineJob job) throws PipelineJobException
     {
         List<Map<String, Object>> toInsert = new ArrayList<>();
         Map<String, Object> row1 = new CaseInsensitiveHashMap<>();

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/PangolinHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/PangolinHandler.java
@@ -193,7 +193,7 @@ public class PangolinHandler extends AbstractParameterizedOutputHandler<Sequence
 
             Container targetContainer = job.getContainer().isWorkbook() ? job.getContainer().getParent() : job.getContainer();
             TableInfo ti = QueryService.get().getUserSchema(job.getUser(), targetContainer, SequenceAnalysisSchema.SCHEMA_NAME).getTable(SequenceAnalysisSchema.TABLE_QUALITY_METRICS);
-            Set<Integer> uniqueAnalyses = inputFiles.stream().map(SequenceOutputFile::getAnalysis_id).collect(Collectors.toSet());
+            Set<Long> uniqueAnalyses = inputFiles.stream().map(SequenceOutputFile::getAnalysis_id).collect(Collectors.toSet());
             SimpleFilter filter = new SimpleFilter(FieldKey.fromString("category"), "Pangolin");
             filter.addCondition(FieldKey.fromString("analysis_id"), uniqueAnalyses, CompareType.IN);
 

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/SequenceBasedTypingAnalysis.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/SequenceBasedTypingAnalysis.java
@@ -376,10 +376,10 @@ public class SequenceBasedTypingAnalysis extends AbstractPipelineStep implements
 
     public static class AlignmentGroupCompare
     {
-        private final int analysisId;
+        private final long analysisId;
         private final List<AlignmentGroup> groups = new ArrayList<>();
 
-        public AlignmentGroupCompare(final int analysisId, Container c, User u)
+        public AlignmentGroupCompare(final long analysisId, Container c, User u)
         {
             this.analysisId = analysisId;
 
@@ -544,7 +544,7 @@ public class SequenceBasedTypingAnalysis extends AbstractPipelineStep implements
 
         public static class AlignmentGroup
         {
-            int analysisId;
+            long analysisId;
             Set<String> alleles = new TreeSet<>();
             String lineages;
             int totalLineages;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/ViralSnpUtil.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/ViralSnpUtil.java
@@ -69,13 +69,13 @@ public class ViralSnpUtil
         return consensusMap;
     }
 
-    public static void deleteExistingMetrics(PipelineJob job, int analysisId, String category) throws PipelineJobException
+    public static void deleteExistingMetrics(PipelineJob job, long analysisId, String category) throws PipelineJobException
     {
         SimpleFilter filter = new SimpleFilter(FieldKey.fromString("category"), category);
         deleteExistingValues(job, analysisId, SequenceAnalysisSchema.TABLE_QUALITY_METRICS, filter);
     }
 
-    public static void deleteExistingValues(PipelineJob job, int analysisId, String queryName, SimpleFilter filter) throws PipelineJobException
+    public static void deleteExistingValues(PipelineJob job, long analysisId, String queryName, SimpleFilter filter) throws PipelineJobException
     {
         Container targetContainer = job.getContainer().isWorkbook() ? job.getContainer().getParent() : job.getContainer();
         TableInfo ti = QueryService.get().getUserSchema(job.getUser(), targetContainer, SequenceAnalysisSchema.SCHEMA_NAME).getTable(queryName);

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/ViralSnpUtil.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/ViralSnpUtil.java
@@ -3,6 +3,7 @@ package org.labkey.sequenceanalysis.run.analysis;
 import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFFileReader;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.SimpleFilter;
@@ -18,7 +19,6 @@ import org.labkey.sequenceanalysis.SequenceAnalysisSchema;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -40,7 +40,7 @@ public class ViralSnpUtil
 
     public static Map<Integer, List<VariantContext>> readVcfToMap(File vcf)
     {
-        Map<Integer, List<VariantContext>> consensusMap = new HashMap<>();
+        Map<Integer, List<VariantContext>> consensusMap = new IntHashMap<>();
         try (VCFFileReader reader = new VCFFileReader(vcf); CloseableIterator<VariantContext> it = reader.iterator())
         {
             while (it.hasNext())

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/AbstractGenomicsDBImportHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/AbstractGenomicsDBImportHandler.java
@@ -162,7 +162,7 @@ abstract public class AbstractGenomicsDBImportHandler extends AbstractParameteri
             throw new IllegalArgumentException("No library ID defined for VCFs");
         }
 
-        Set<Integer> readsetIds = new HashSet<>();
+        Set<Long> readsetIds = new HashSet<>();
         inputFiles.forEach(x -> readsetIds.add(x.getReadset()));
 
         int sampleCount = getSamplesForWorkspace(mergedWorkspace.getParentFile()).size();

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/util/ChainFileValidator.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/util/ChainFileValidator.java
@@ -7,6 +7,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.IntHashMap;
+import org.labkey.api.collections.IntHashSet;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.Results;
@@ -59,8 +61,8 @@ public class ChainFileValidator
         // reference names must match those in the DB for that genome
 
         Pattern SPLITTER = Pattern.compile("\\s");
-        Set<Integer> uniqueIds = new HashSet<>();
-        Set<Integer> encounteredIds = new HashSet<>();
+        Set<Integer> uniqueIds = new IntHashSet();
+        Set<Integer> encounteredIds = new IntHashSet();
 
         //step 1: iterate lines, gather unique chain IDs
         boolean hasChanges = false;
@@ -284,7 +286,7 @@ public class ChainFileValidator
         return newId;
     }
 
-    private final Map<Integer, Map<String, String>> _cachedReferencesByGenome = new HashMap<>();
+    private final Map<Integer, Map<String, String>> _cachedReferencesByGenome = new IntHashMap<>();
 
     private String resolveSequenceId(String refName, int genomeId)
     {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/util/TranslatingReferenceSequence.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/util/TranslatingReferenceSequence.java
@@ -17,6 +17,7 @@ package org.labkey.sequenceanalysis.util;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
@@ -29,7 +30,6 @@ import org.labkey.sequenceanalysis.run.util.AASnp;
 import org.labkey.sequenceanalysis.run.util.NTSnp;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -231,7 +231,7 @@ public class TranslatingReferenceSequence
                     StringBuilder codon = new StringBuilder();
 
                     //to track the SNPs that comprise this codon, 0-based
-                    Map<Integer, NTSnp> snpMap = new HashMap<>();
+                    Map<Integer, NTSnp> snpMap = new IntHashMap<>();
                     Integer positionInCodon = null; //0-based
                     for (Integer p : positions) //1-based
                     {
@@ -240,7 +240,7 @@ public class TranslatingReferenceSequence
                         {
                             StringBuilder thisSegment = new StringBuilder();
                             int positionInSegment = 0;
-                            Map<Integer, NTSnp> snpMapForSegment = new HashMap<>(); //0-based
+                            Map<Integer, NTSnp> snpMapForSegment = new IntHashMap<>(); //0-based
 
                             //force sorting by idx
                             List<NTSnp> otherSnps = readSnps.get(position);

--- a/Studies/src/org/labkey/studies/StudiesManager.java
+++ b/Studies/src/org/labkey/studies/StudiesManager.java
@@ -50,6 +50,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.fasterxml.jackson.databind.type.LogicalType.Collection;
+import static org.labkey.api.exp.api.ExperimentService.asInteger;
 
 @RunWith(Enclosed.class)
 public class StudiesManager
@@ -149,7 +150,7 @@ public class StudiesManager
         if (bve.hasErrors())
             throw bve;
 
-        sd.setRowId((Integer) ret.get(0).get("rowId"));
+        sd.setRowId(asInteger(ret.get(0).get("rowId")));
         return sd;
     }
 
@@ -208,7 +209,7 @@ public class StudiesManager
         {
             List<Map<String,Object>> ret = qus.insertRows(u, c, inserts, bve, null, null);
             for (int i = 0; i < ret.size(); i++)
-                setRowId.set(insertBeans.get(i), (Integer) ret.get(i).get("rowId"));
+                setRowId.set(insertBeans.get(i), asInteger(ret.get(i).get("rowId")));
         }
 
         if (!updates.isEmpty())

--- a/blast/src/org/labkey/blast/model/BlastJob.java
+++ b/blast/src/org/labkey/blast/model/BlastJob.java
@@ -61,7 +61,7 @@ public class BlastJob implements Serializable
     private int _modifiedBy;
     private Date _modified;
     private String _jobId;
-    private Integer _htmlFile;
+    private Long _htmlFile;
     private File _outputDir = null;
     
     public BlastJob()
@@ -231,12 +231,12 @@ public class BlastJob implements Serializable
         _jobId = jobId;
     }
 
-    public Integer getHtmlFile()
+    public Long getHtmlFile()
     {
         return _htmlFile;
     }
 
-    public void setHtmlFile(Integer htmlFile)
+    public void setHtmlFile(Long htmlFile)
     {
         _htmlFile = htmlFile;
     }
@@ -341,7 +341,7 @@ public class BlastJob implements Serializable
             return false;
         }
 
-        Integer jobId = PipelineService.get().getJobId(u, ContainerManager.getForId(getContainer()), getJobId());
+        Long jobId = PipelineService.get().getJobId(u, ContainerManager.getForId(getContainer()), getJobId());
         PipelineStatusFile statusFile = PipelineService.get().getStatusFile(jobId);
         return "ERROR".equalsIgnoreCase(statusFile.getStatus());
     }

--- a/cluster/src/org/labkey/cluster/pipeline/ClusterJob.java
+++ b/cluster/src/org/labkey/cluster/pipeline/ClusterJob.java
@@ -9,7 +9,7 @@ public class ClusterJob
 {
     private int _rowId;
     private String _jobId;
-    private int _statusFileId;
+    private long _statusFileId;
     private String _status;
     private Boolean _hasStarted;
     private String _clusterId;
@@ -169,12 +169,12 @@ public class ClusterJob
         _clusterUser = clusterUser;
     }
 
-    public int getStatusFileId()
+    public long getStatusFileId()
     {
         return _statusFileId;
     }
 
-    public void setStatusFileId(int statusFileId)
+    public void setStatusFileId(long statusFileId)
     {
         _statusFileId = statusFileId;
     }

--- a/jbrowse/src/org/labkey/jbrowse/pipeline/JBrowseSessionTask.java
+++ b/jbrowse/src/org/labkey/jbrowse/pipeline/JBrowseSessionTask.java
@@ -44,6 +44,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
+import static org.labkey.api.exp.api.ExperimentService.asInteger;
+
 /**
  * User: bbimber
  * Date: 8/6/12
@@ -254,7 +256,7 @@ public class JBrowseSessionTask extends PipelineJob.Task<JBrowseSessionTask.Fact
                     trackRecord.put("modified", new Date());
                     trackRecord.put("modifiedby", getJob().getUser().getUserId());
                     trackRecord = Table.insert(getJob().getUser(), databaseMembers, trackRecord);
-                    databaseMemberRecordsCreated.add((Integer)trackRecord.get("rowid"));
+                    databaseMemberRecordsCreated.add(asInteger(trackRecord.get("rowid")));
 
                     json.prepareResource(getJob().getUser(), getJob().getLogger(), false, false);
                 }
@@ -305,7 +307,7 @@ public class JBrowseSessionTask extends PipelineJob.Task<JBrowseSessionTask.Fact
                     trackRecord.put("modified", new Date());
                     trackRecord.put("modifiedby", getJob().getUser().getUserId());
                     trackRecord = Table.insert(getJob().getUser(), databaseMembers, trackRecord);
-                    databaseMemberRecordsCreated.add((Integer) trackRecord.get("rowid"));
+                    databaseMemberRecordsCreated.add(asInteger(trackRecord.get("rowid")));
 
                     json.prepareResource(getJob().getUser(), getJob().getLogger(), false, false);
                 }

--- a/singlecell/api-src/org/labkey/api/singlecell/CellHashingService.java
+++ b/singlecell/api-src/org/labkey/api/singlecell/CellHashingService.java
@@ -52,7 +52,7 @@ abstract public class CellHashingService
 
     abstract public File generateHashingCallsForRawMatrix(Readset parentReadset, PipelineOutputTracker output, SequenceOutputHandler.JobContext ctx, CellHashingParameters parameters, File rawCountMatrixDir) throws PipelineJobException;
 
-    abstract public File getH5FileForGexReadset(SequenceAnalysisJobSupport support, int readsetId, int genomeId) throws PipelineJobException;
+    abstract public File getH5FileForGexReadset(SequenceAnalysisJobSupport support, long readsetId, int genomeId) throws PipelineJobException;
 
     abstract public File getCDNAInfoFile(File sourceDir);
 
@@ -76,7 +76,7 @@ abstract public class CellHashingService
 
     abstract public List<ToolParameterDescriptor> getHashingCallingParams(boolean allowMethodsNeedingGex);
 
-    abstract public Set<String> getHtosForParentReadset(Integer parentReadsetId, File webserverJobDir, SequenceAnalysisJobSupport support, boolean throwIfNotFound) throws PipelineJobException;
+    abstract public Set<String> getHtosForParentReadset(Long parentReadsetId, File webserverJobDir, SequenceAnalysisJobSupport support, boolean throwIfNotFound) throws PipelineJobException;
 
     abstract public File getExistingFeatureBarcodeCountDir(Readset parentReadset, BARCODE_TYPE type, SequenceAnalysisJobSupport support) throws PipelineJobException;
 
@@ -232,7 +232,7 @@ abstract public class CellHashingService
             return Collections.emptyList();
         }
 
-        public int getEffectiveReadsetId()
+        public long getEffectiveReadsetId()
         {
             return parentReadset != null ? parentReadset.getReadsetId() : htoReadset.getReadsetId();
         }

--- a/singlecell/api-src/org/labkey/api/singlecell/pipeline/AbstractSingleCellPipelineStep.java
+++ b/singlecell/api-src/org/labkey/api/singlecell/pipeline/AbstractSingleCellPipelineStep.java
@@ -128,7 +128,7 @@ abstract public class AbstractSingleCellPipelineStep extends AbstractPipelineSte
                     throw new PipelineJobException("Unable to parse readsetId: " + readsetIdVal);
                 }
 
-                outputs.add(new SeuratObjectWrapper(line[0], line[1], f, outputIdVal == null ? null : Integer.parseInt(outputIdVal), readsetIdVal == null ? null : Integer.parseInt(readsetIdVal)));
+                outputs.add(new SeuratObjectWrapper(line[0], line[1], f, outputIdVal == null ? null : Integer.parseInt(outputIdVal), readsetIdVal == null ? null : Long.parseLong(readsetIdVal)));
             }
         }
         catch (IOException e)

--- a/singlecell/api-src/org/labkey/api/singlecell/pipeline/AbstractSingleCellStep.java
+++ b/singlecell/api-src/org/labkey/api/singlecell/pipeline/AbstractSingleCellStep.java
@@ -64,7 +64,7 @@ public interface AbstractSingleCellStep extends PipelineStep
         private transient SequenceOutputFile _sequenceOutputFile;
 
         private Integer _sequenceOutputFileId;
-        private Integer _readsetId;
+        private Long _readsetId;
 
         private File _file;
         private String _datasetId;
@@ -87,7 +87,7 @@ public interface AbstractSingleCellStep extends PipelineStep
 
         }
 
-        public SeuratObjectWrapper(String datasetId, String datasetName, File file, @Nullable Integer sequenceOutputFileId, @Nullable Integer readsetId)
+        public SeuratObjectWrapper(String datasetId, String datasetName, File file, @Nullable Integer sequenceOutputFileId, @Nullable Long readsetId)
         {
             _datasetId = datasetId;
             _datasetName = datasetName;
@@ -127,12 +127,12 @@ public interface AbstractSingleCellStep extends PipelineStep
             _datasetName = datasetName;
         }
 
-        public Integer getReadsetId()
+        public Long getReadsetId()
         {
             return _readsetId;
         }
 
-        public void setReadsetId(Integer readsetId)
+        public void setReadsetId(Long readsetId)
         {
             _readsetId = readsetId;
         }

--- a/singlecell/src/org/labkey/singlecell/CellHashingServiceImpl.java
+++ b/singlecell/src/org/labkey/singlecell/CellHashingServiceImpl.java
@@ -10,6 +10,8 @@ import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
+import org.labkey.api.collections.IntHashMap;
+import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
@@ -139,10 +141,10 @@ public class CellHashingServiceImpl extends CellHashingService
         File output = getCDNAInfoFile(sourceDir);
         File barcodeOutput = getValidHashingBarcodeFile(sourceDir);
         HashMap<String, Integer> gexReadsetToH5Map = new HashMap<>();
-        HashMap<Integer, Integer> readsetToHashingMap = new HashMap<>();
-        HashMap<Integer, Integer> readsetToCiteSeqMap = new HashMap<>();
-        HashMap<Integer, Integer> readsetToGexMap = new HashMap<>();
-        HashMap<Integer, Set<String>> gexToPanels = new HashMap<>();
+        HashMap<Long, Integer> readsetToHashingMap = new LongHashMap<>();
+        HashMap<Long, Integer> readsetToCiteSeqMap = new LongHashMap<>();
+        HashMap<Long, Integer> readsetToGexMap = new LongHashMap<>();
+        HashMap<Long, Set<String>> gexToPanels = new LongHashMap<>();
 
         List<Readset> cachedReadsets = support.getCachedReadsets();
         job.getLogger().debug("Total cached readsets: " + cachedReadsets.size() + ", using filter on: " + filterField);
@@ -279,7 +281,7 @@ public class CellHashingServiceImpl extends CellHashingService
             HashMap<String, File> readsetToCountMap = new HashMap<>();
             if (distinctHTOs.size() > 1)
             {
-                Set<Integer> hashingToRemove = new HashSet<>();
+                Set<Long> hashingToRemove = new HashSet<>();
                 readsetToHashingMap.forEach((readsetId, hashingReadsetId) -> {
                     if (cacheCountMatrixFiles)
                     {
@@ -342,7 +344,7 @@ public class CellHashingServiceImpl extends CellHashingService
                 job.getLogger().info("distinct HTOs: " + distinctHTOs.size());
             }
 
-            Set<Integer> citeToRemove = new HashSet<>();
+            Set<Long> citeToRemove = new HashSet<>();
             readsetToCiteSeqMap.forEach((readsetId, citeseqReadsetId) -> {
                 if (cacheCountMatrixFiles)
                 {
@@ -433,7 +435,7 @@ public class CellHashingServiceImpl extends CellHashingService
         }
     }
 
-    private Map<String, Integer> cacheH5Files(PipelineJob job, SequenceAnalysisJobSupport support, Collection<Integer> uniqueGex, Map<Integer, Integer> readsetToGexMap) throws PipelineJobException
+    private Map<String, Integer> cacheH5Files(PipelineJob job, SequenceAnalysisJobSupport support, Collection<Integer> uniqueGex, Map<Long, Integer> readsetToGexMap) throws PipelineJobException
     {
         job.getLogger().debug("Caching H5 Files");
         Map<String, Integer> gexReadsetToH5Map = new HashMap<>();
@@ -441,7 +443,7 @@ public class CellHashingServiceImpl extends CellHashingService
         TableInfo ti = QueryService.get().getUserSchema(job.getUser(), job.getContainer().isWorkbook() ? job.getContainer().getParent() : job.getContainer(), SingleCellSchema.SEQUENCE_SCHEMA_NAME).getTable("outputfiles");
         Set<Integer> cachedGenomes = support.getCachedGenomes().stream().map(ReferenceGenome::getGenomeId).collect(Collectors.toSet());
 
-        for (int readsetId : readsetToGexMap.keySet())
+        for (long readsetId : readsetToGexMap.keySet())
         {
             boolean isGEX = uniqueGex.contains(readsetId);
             int gexReadset = readsetToGexMap.get(readsetId);
@@ -514,17 +516,17 @@ public class CellHashingServiceImpl extends CellHashingService
         return gexReadsetToH5Map;
     }
 
-    public File getValidCiteSeqBarcodeFile(File sourceDir, int gexReadsetId)
+    public File getValidCiteSeqBarcodeFile(File sourceDir, long gexReadsetId)
     {
         return new File(sourceDir, "validADTS." + gexReadsetId + ".csv");
     }
 
-    public File getValidCiteSeqBarcodeMetadataFile(File sourceDir, int gexReadsetId)
+    public File getValidCiteSeqBarcodeMetadataFile(File sourceDir, long gexReadsetId)
     {
         return new File(sourceDir, "validADTS." + gexReadsetId + ".metadata.txt");
     }
 
-    private void writeCiteSeqBarcodes(PipelineJob job, Map<Integer, Set<String>> gexToPanels, File outputDir) throws PipelineJobException
+    private void writeCiteSeqBarcodes(PipelineJob job, Map<Long, Set<String>> gexToPanels, File outputDir) throws PipelineJobException
     {
         Container target = job.getContainer().isWorkbook() ? job.getContainer().getParent() : job.getContainer();
         UserSchema schema = QueryService.get().getUserSchema(job.getUser(), target, SingleCellSchema.NAME);
@@ -539,7 +541,7 @@ public class CellHashingServiceImpl extends CellHashingService
                 FieldKey.fromString("antibody/barcodePattern")
         ));
 
-        for (int gexReadsetId : gexToPanels.keySet())
+        for (long gexReadsetId : gexToPanels.keySet())
         {
             job.getLogger().info("Writing all unique ADTs for readset: " + gexReadsetId);
             File barcodeOutput = getValidCiteSeqBarcodeFile(outputDir, gexReadsetId);
@@ -595,7 +597,7 @@ public class CellHashingServiceImpl extends CellHashingService
         }
 
         parameters.validate(true);
-        Map<Integer, Integer> readsetToHashing = getCachedHashingReadsetMap(ctx.getSequenceSupport());
+        Map<Long, Long> readsetToHashing = getCachedHashingReadsetMap(ctx.getSequenceSupport());
         if (readsetToHashing.isEmpty())
         {
             ctx.getLogger().info("No cached " + parameters.type.name() + " readsets, skipping");
@@ -721,7 +723,7 @@ public class CellHashingServiceImpl extends CellHashingService
         return callsFile;
     }
 
-    private Map<Integer, Integer> getCachedCiteSeqReadsetMap(SequenceAnalysisJobSupport support) throws PipelineJobException
+    private Map<Long, Long> getCachedCiteSeqReadsetMap(SequenceAnalysisJobSupport support) throws PipelineJobException
     {
         return support.getCachedObject(READSET_TO_CITESEQ_MAP, PipelineJob.createObjectMapper().getTypeFactory().constructParametricType(Map.class, Integer.class, Integer.class));
     }
@@ -729,7 +731,7 @@ public class CellHashingServiceImpl extends CellHashingService
     @Override
     public boolean usesCellHashing(SequenceAnalysisJobSupport support, File sourceDir) throws PipelineJobException
     {
-        Map<Integer, Integer> gexToHashingMap = getCachedHashingReadsetMap(support);
+        Map<Long, Long> gexToHashingMap = getCachedHashingReadsetMap(support);
         if (gexToHashingMap == null || gexToHashingMap.isEmpty())
             return false;
 
@@ -745,7 +747,7 @@ public class CellHashingServiceImpl extends CellHashingService
     @Override
     public boolean usesCiteSeq(SequenceAnalysisJobSupport support, List<SequenceOutputFile> inputFiles) throws PipelineJobException
     {
-        Map<Integer, Integer> gexToCiteMap = getCachedCiteSeqReadsetMap(support);
+        Map<Long, Long> gexToCiteMap = getCachedCiteSeqReadsetMap(support);
         if (gexToCiteMap == null || gexToCiteMap.isEmpty())
             return false;
 
@@ -761,7 +763,7 @@ public class CellHashingServiceImpl extends CellHashingService
     }
 
     @Override
-    public File getH5FileForGexReadset(SequenceAnalysisJobSupport support, int readsetId, int genomeId) throws PipelineJobException
+    public File getH5FileForGexReadset(SequenceAnalysisJobSupport support, long readsetId, int genomeId) throws PipelineJobException
     {
         Map<String, Integer> map = support.getCachedObject(READSET_AND_GENOME_TO_H5_MAP, PipelineJob.createObjectMapper().getTypeFactory().constructParametricType(Map.class, String.class, Integer.class));
         String key = readsetId + "-" + genomeId;
@@ -797,12 +799,12 @@ public class CellHashingServiceImpl extends CellHashingService
         return new File(sourceDir, "cDNAInfo.txt");
     }
     
-    public Map<Integer, Integer> getCachedHashingReadsetMap(SequenceAnalysisJobSupport support) throws PipelineJobException
+    public Map<Long, Long> getCachedHashingReadsetMap(SequenceAnalysisJobSupport support) throws PipelineJobException
     {
         return support.getCachedObject(READSET_TO_HASHING_MAP, PipelineJob.createObjectMapper().getTypeFactory().constructParametricType(Map.class, Integer.class, Integer.class));
     }
 
-    public File getCachedReadsetToCountMatrix(SequenceAnalysisJobSupport support, int readsetId, CellHashingService.BARCODE_TYPE type) throws PipelineJobException
+    public File getCachedReadsetToCountMatrix(SequenceAnalysisJobSupport support, long readsetId, CellHashingService.BARCODE_TYPE type) throws PipelineJobException
     {
         Map<String, File> map = support.getCachedObject(READSET_TO_COUNTS_MAP, PipelineJob.createObjectMapper().getTypeFactory().constructParametricType(Map.class, String.class, File.class));
         String key = type.name() + "-" + readsetId;
@@ -1367,7 +1369,7 @@ public class CellHashingServiceImpl extends CellHashingService
     @Override
     public File getExistingFeatureBarcodeCountDir(Readset parentReadset, BARCODE_TYPE type, SequenceAnalysisJobSupport support) throws PipelineJobException
     {
-        Integer childId = type == BARCODE_TYPE.hashing ? getCachedHashingReadsetMap(support).get(parentReadset.getReadsetId()) : getCachedCiteSeqReadsetMap(support).get(parentReadset.getReadsetId());
+        Long childId = type == BARCODE_TYPE.hashing ? getCachedHashingReadsetMap(support).get(parentReadset.getReadsetId()) : getCachedCiteSeqReadsetMap(support).get(parentReadset.getReadsetId());
         if (childId == null)
         {
             throw new PipelineJobException("Unable to find cached readset of type " + type.name() + " for parent: " + parentReadset.getReadsetId());
@@ -1416,9 +1418,9 @@ public class CellHashingServiceImpl extends CellHashingService
     }
 
     @Override
-    public Set<String> getHtosForParentReadset(Integer parentReadsetId, File webserverJobDir, SequenceAnalysisJobSupport support, boolean throwIfNotFound) throws PipelineJobException
+    public Set<String> getHtosForParentReadset(Long parentReadsetId, File webserverJobDir, SequenceAnalysisJobSupport support, boolean throwIfNotFound) throws PipelineJobException
     {
-        Integer htoReadset = getCachedHashingReadsetMap(support).get(parentReadsetId);
+        Long htoReadset = getCachedHashingReadsetMap(support).get(parentReadsetId);
         if (htoReadset == null)
         {
             if (throwIfNotFound)
@@ -1434,7 +1436,7 @@ public class CellHashingServiceImpl extends CellHashingService
         return getHtosForReadset(htoReadset, webserverJobDir);
     }
 
-    public Set<String> getHtosForReadset(Integer hashingReadsetId, File webserverJobDir) throws PipelineJobException
+    public Set<String> getHtosForReadset(Long hashingReadsetId, File webserverJobDir) throws PipelineJobException
     {
         Set<String> htosPerReadset = new HashSet<>();
         try (CSVReader reader = new CSVReader(Readers.getReader(CellHashingServiceImpl.get().getCDNAInfoFile(webserverJobDir)), '\t'))

--- a/singlecell/src/org/labkey/singlecell/analysis/AbstractSingleCellHandler.java
+++ b/singlecell/src/org/labkey/singlecell/analysis/AbstractSingleCellHandler.java
@@ -373,7 +373,7 @@ abstract public class AbstractSingleCellHandler implements SequenceOutputHandler
             String basename;
             if (inputFiles.size() == 1 && inputFiles.get(0).getReadset() != null)
             {
-                Integer readsetId = inputFiles.get(0).getReadset();
+                Long readsetId = inputFiles.get(0).getReadset();
                 Readset rs = ctx.getSequenceSupport().getCachedReadset(readsetId);
                 basename = FileUtil.makeLegalName(rs.getName()).replaceAll(" ", "_");
             }

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/AppendCiteSeq.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/AppendCiteSeq.java
@@ -2,6 +2,7 @@ package org.labkey.singlecell.pipeline.singlecell;
 
 import org.apache.commons.io.FileUtils;
 import org.json.JSONObject;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.SequenceOutputFile;
 import org.labkey.api.sequenceanalysis.model.Readset;
@@ -21,7 +22,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -88,7 +88,7 @@ public class AppendCiteSeq extends AbstractCellHashingCiteseqStep
     @Override
     protected Map<Integer, File> prepareCountData(SingleCellOutput output, SequenceOutputHandler.JobContext ctx, List<SeuratObjectWrapper> inputObjects, String outputPrefix) throws PipelineJobException
     {
-        Map<Integer, File> dataIdToCalls = new HashMap<>();
+        Map<Integer, File> dataIdToCalls = new IntHashMap<>();
 
         boolean dropAggregateBarcodes = getProvider().getParameterByName("dropAggregateBarcodes").extractValue(getPipelineCtx().getJob(), getProvider(), getStepIdx(), Boolean.class, true);
         for (SeuratObjectWrapper wrapper : inputObjects)

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/AppendSaturation.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/AppendSaturation.java
@@ -4,6 +4,8 @@ import au.com.bytecode.opencsv.CSVReader;
 import au.com.bytecode.opencsv.CSVWriter;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.labkey.api.collections.IntHashMap;
+import org.labkey.api.collections.IntHashSet;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
@@ -25,8 +27,6 @@ import org.labkey.singlecell.SingleCellSchema;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -59,7 +59,7 @@ public class AppendSaturation extends AbstractCellMembraneStep
     {
         try (CSVWriter writer = new CSVWriter(PrintWriters.getPrintWriter(getMolInfoTable(ctx))))
         {
-            Map<Integer, SequenceOutputFile> loupeOutputs = new HashMap<>();
+            Map<Integer, SequenceOutputFile> loupeOutputs = new IntHashMap<>();
             for (SequenceOutputFile so : inputFiles)
             {
                 if (!LOUPE_TYPE.isType(so.getFile()))
@@ -75,7 +75,7 @@ public class AppendSaturation extends AbstractCellMembraneStep
                         throw new PipelineJobException("Cannot find expected metadata file: " + meta.getPath());
                     }
 
-                    Set<Integer> uniqueIds = new HashSet<>();
+                    Set<Integer> uniqueIds = new IntHashSet();
                     try (CSVReader reader = new CSVReader(Readers.getReader(meta), '_'))
                     {
                         String[] line;
@@ -200,7 +200,7 @@ public class AppendSaturation extends AbstractCellMembraneStep
 
     private void findAdditionalData(SequenceOutputFile loupeFile, CSVWriter writer, PipelineJob job) throws IOException, PipelineJobException
     {
-        Set<Integer> citeReadsets = new HashSet<>();
+        Set<Integer> citeReadsets = new IntHashSet();
         Container targetContainer = job.getContainer().isWorkbook() ? job.getContainer().getParent() : job.getContainer();
         TableSelector ts = new TableSelector(QueryService.get().getUserSchema(job.getUser(), targetContainer, SingleCellSchema.NAME).getTable(SingleCellSchema.TABLE_CDNAS), PageFlowUtil.set("hashingReadsetId", "citeseqReadsetId"), new SimpleFilter(FieldKey.fromString("readsetId"), loupeFile.getReadset()), null);
         ts.forEachResults(rs -> {

--- a/singlecell/src/org/labkey/singlecell/pipeline/singlecell/RunCellHashing.java
+++ b/singlecell/src/org/labkey/singlecell/pipeline/singlecell/RunCellHashing.java
@@ -2,6 +2,7 @@ package org.labkey.singlecell.pipeline.singlecell;
 
 import au.com.bytecode.opencsv.CSVReader;
 import org.apache.commons.io.FileUtils;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.reader.Readers;
 import org.labkey.api.sequenceanalysis.SequenceOutputFile;
@@ -25,7 +26,6 @@ import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -80,7 +80,7 @@ public class RunCellHashing extends AbstractCellHashingCiteseqStep
     @Override
     protected Map<Integer, File> prepareCountData(SingleCellOutput output, SequenceOutputHandler.JobContext ctx, List<SeuratObjectWrapper> inputObjects, String outputPrefix) throws PipelineJobException
     {
-        Map<Integer, File> dataIdToCalls = new HashMap<>();
+        Map<Integer, File> dataIdToCalls = new IntHashMap<>();
 
         for (SeuratObjectWrapper wrapper : inputObjects)
         {

--- a/singlecell/src/org/labkey/singlecell/run/CellRangerFeatureBarcodeHandler.java
+++ b/singlecell/src/org/labkey/singlecell/run/CellRangerFeatureBarcodeHandler.java
@@ -194,7 +194,7 @@ public class CellRangerFeatureBarcodeHandler extends AbstractParameterizedOutput
                 action.addInputIfNotPresent(rd.getFile2(), "Input FASTQ");
             });
 
-            Integer gexReadsetId = ctx.getSequenceSupport().getCachedObject(FEATURE_TO_GEX, Integer.class);
+            Long gexReadsetId = ctx.getSequenceSupport().getCachedObject(FEATURE_TO_GEX, Long.class);
             if (gexReadsetId != null)
             {
                 ctx.getLogger().info("Adding GEX FASTQs");

--- a/singlecell/src/org/labkey/singlecell/run/CellRangerGexCountStep.java
+++ b/singlecell/src/org/labkey/singlecell/run/CellRangerGexCountStep.java
@@ -489,7 +489,7 @@ public class CellRangerGexCountStep extends AbstractAlignmentPipelineStep<CellRa
         }
 
         File outsDir = outputForData.getFile().getParentFile();
-        Integer dataId = outputForData.getDataId();
+        Long dataId = outputForData.getDataId();
         if (dataId == null)
         {
             throw new PipelineJobException("Unable to find dataId for output file");

--- a/singlecell/src/org/labkey/singlecell/run/CellRangerVDJWrapper.java
+++ b/singlecell/src/org/labkey/singlecell/run/CellRangerVDJWrapper.java
@@ -696,7 +696,7 @@ public class CellRangerVDJWrapper extends AbstractCommandWrapper
             }
         }
 
-        public void addMetrics(File outDir, AnalysisModel model, int dataId) throws PipelineJobException
+        public void addMetrics(File outDir, AnalysisModel model, long dataId) throws PipelineJobException
         {
             getPipelineCtx().getLogger().debug("adding 10x metrics");
 
@@ -810,7 +810,7 @@ public class CellRangerVDJWrapper extends AbstractCommandWrapper
                 folderWithMetricFile = outputForData.getFile().getParentFile().getParentFile();
             }
 
-            Integer dataId = outputForData.getDataId();
+            Long dataId = outputForData.getDataId();
             if (dataId == null)
             {
                 throw new PipelineJobException("Unable to find dataId for output file");


### PR DESCRIPTION
#### Rationale
Implement support for tables with BIGINT primary keys.  E.g. RowId/ObjectId BIGSERIAL
Because of the large number of shared classes, utilities, services, etc, a lot of code was migrated to used Long.  Code should now assume that an generic integer object key (as opposed to a known table PK), could be a Long.

This PR is aimed at a) Supporting ObjectID BIGSERIAL b) making it possible (but not automatic) to migrate tables that want to use RowId BIGSERIAL.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
New safer collection classes
  class Int/LongHashMap
  class Int/LongHashSet
explicit Class for key values in Map Objects returned by BaseSelector
  Selector.getValueMap(Class key)
safe "cast" using asInteger or asLong, as opposed to (Integer) and (Long)

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->
