### PR TITLE
Remove reference to deprecated "startTomcat" gradle task

### DIFF
--- a/SequenceAnalysis/build.gradle
+++ b/SequenceAnalysis/build.gradle
@@ -195,13 +195,10 @@ if (project.findProject(BuildUtils.getTestProjectPath(project.gradle)) != null &
             })
             task.destinationDir = configDir
 
-            rootProject.allprojects {
-                task.mustRunAfter tasks.withType(DoThenSetup)
-            }
     }
-    testProject.tasks.named("startTomcat").configure {
+    testProject.tasks.withType(DoThenSetup).configureEach {
         dependsOn(createPipelineConfigTask)
-        it.doFirst {
+        it.doLast {
             new File(new File(BuildUtils.getEmbeddedConfigPath(project)), "application.properties")
                     << "\ncontext.pipelineConfig=${configDir.getAbsolutePath().replace("\\", "\\\\")}"
         }


### PR DESCRIPTION
#### Rationale
The existing code customizes ":testAutomation:startTomcat" to append an extra property to the server's `application.properties`.
"stopTomcat" is going away. Instead of updating this to reference "startLabKey", I'm updating it to match the similar code in the [premium](https://github.com/LabKey/premiumModules/blob/c0a3f8c2636b4589fa32b25f859163427f42e932/premium/build.gradle#L50) module. Instead of using `doFirst` to update application.properties before starting tomcat, it uses `doLast` to update it after `pickPg`/`pickMssql`.

`createPipelineConfigTask.mustRunAfter tasks.withType(DoThenSetup)` is leftover from how that file was handled when running standalone Tomcat. It should be safe to remove.

#### Related Pull Requests
* https://github.com/LabKey/kanban/issues/994

#### Changes
* Remove reference to deprecated "startTomcat" gradle task
