### PR TITLE
Don't need to check for SearchService; it falls back to a no-op now

### DIFF
--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisModule.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisModule.java
@@ -494,10 +494,7 @@ public class SequenceAnalysisModule extends ExtendedSimpleModule
 
         ExperimentService.get().registerExperimentDataHandler(new HtmlExpDataHandler());
 
-        SearchService ss = SearchService.get();
-
-        if (null != ss)
-            ss.addDocumentParser(new SequenceNoOpDocumentParser());
+        SearchService.get().addDocumentParser(new SequenceNoOpDocumentParser());
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Recent work on the search queue introduced a no-op implementation for the service. Thus, we don't need to check if it's null anymore.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/7035

#### Changes
* Just use the available `SearchService` and let it do nothing if it chooses