### PR TITLE
Update to Gradle 9 and make more progress toward configuration cache compatibility

### DIFF
--- a/SequenceAnalysis/build.gradle
+++ b/SequenceAnalysis/build.gradle
@@ -1,7 +1,7 @@
 import org.labkey.gradle.plugin.TeamCity
 import org.labkey.gradle.plugin.extension.ServerDeployExtension
 import org.labkey.gradle.plugin.extension.TeamCityExtension
-import org.labkey.gradle.task.DoThenSetup
+import org.labkey.gradle.task.SetUpProperties
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
 import org.labkey.gradle.util.PropertiesUtils
@@ -196,7 +196,7 @@ if (project.findProject(BuildUtils.getTestProjectPath(project.gradle)) != null &
             task.destinationDir = configDir
 
     }
-    testProject.tasks.withType(DoThenSetup).configureEach {
+    testProject.tasks.withType(SetUpProperties).configureEach {
         dependsOn(createPipelineConfigTask)
         it.doLast {
             new File(new File(BuildUtils.getEmbeddedConfigPath(project)), "application.properties")


### PR DESCRIPTION
#### Rationale
See related PR

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/234
* https://github.com/LabKey/server/pull/1182

#### Changes
* Use `SetUpProperties` instead of `DoThenSetup` for finding tasks for use in appending ldap properties
