### PR TITLE
Return Set<Class<?>> from Module "get test" methods

### DIFF
--- a/OpenLdapSync/src/org/labkey/openldapsync/OpenLdapSyncModule.java
+++ b/OpenLdapSync/src/org/labkey/openldapsync/OpenLdapSyncModule.java
@@ -119,7 +119,7 @@ public class OpenLdapSyncModule extends SpringModule
     }
 
     @Override
-    public @NotNull Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
         return PageFlowUtil.set(LdapSyncRunner.TestCase.class);
     }

--- a/OpenLdapSync/src/org/labkey/openldapsync/ldap/LdapSyncAuditProvider.java
+++ b/OpenLdapSync/src/org/labkey/openldapsync/ldap/LdapSyncAuditProvider.java
@@ -36,8 +36,8 @@ public class LdapSyncAuditProvider extends AbstractAuditTypeProvider implements 
 
     static final List<FieldKey> defaultVisibleColumns = new ArrayList<>();
 
-    static {
-
+    static
+    {
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_CREATED));
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_CREATED_BY));
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_IMPERSONATED_BY));
@@ -45,6 +45,11 @@ public class LdapSyncAuditProvider extends AbstractAuditTypeProvider implements 
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_USERS_AND_GROUPS_REMOVED));
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_MEMBERSHIPS_CHANGED));
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_COMMENT));
+    }
+
+    public LdapSyncAuditProvider()
+    {
+        super(new LdapSyncAuditDomainKind());
     }
 
     @Override
@@ -68,7 +73,7 @@ public class LdapSyncAuditProvider extends AbstractAuditTypeProvider implements 
     @Override
     public TableInfo createTableInfo(UserSchema userSchema, ContainerFilter cf)
     {
-        DefaultAuditTypeTable table = new DefaultAuditTypeTable(this, createStorageTableInfo(), userSchema, cf, defaultVisibleColumns)
+        return new DefaultAuditTypeTable(LdapSyncAuditProvider.this, createStorageTableInfo(), userSchema, cf, defaultVisibleColumns)
         {
             @Override
             protected void initColumn(MutableColumnInfo col)
@@ -87,19 +92,12 @@ public class LdapSyncAuditProvider extends AbstractAuditTypeProvider implements 
                 }
             }
         };
-        return table;
     }
 
     @Override
     public List<FieldKey> getDefaultVisibleColumns()
     {
         return defaultVisibleColumns;
-    }
-
-    @Override
-    protected AbstractAuditDomainKind getDomainKind()
-    {
-        return new LdapSyncAuditDomainKind();
     }
 
     @Override

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisModule.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisModule.java
@@ -505,40 +505,35 @@ public class SequenceAnalysisModule extends ExtendedSimpleModule
     }
 
     @Override
-    @NotNull
-    public Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
-        @SuppressWarnings({"unchecked"})
-        Set<Class> testClasses = new HashSet<>(Arrays.asList(
-                Barcoder.TestCase.class,
-                BamIterator.TestCase.class,
-                SequenceIntegrationTests.SequenceImportPipelineTestCase.class,
-                //SequenceIntegrationTests.SequenceAnalysisPipelineTestCase3.class,
-                SequenceIntegrationTests.SequenceAnalysisPipelineTestCase1.class,
-                SequenceIntegrationTests.SequenceAnalysisPipelineTestCase2.class,
-                OutputIntegrationTests.VariantProcessingTest.class,
-                SequenceRemoteIntegrationTests.class,
-                SequenceTriggerHelper.TestCase.class,
-                SequencePipelineServiceImpl.TestCase.class
-        ));
-
-        return testClasses;
+        return Set.of(
+            Barcoder.TestCase.class,
+            BamIterator.TestCase.class,
+            SequenceIntegrationTests.SequenceImportPipelineTestCase.class,
+            //SequenceIntegrationTests.SequenceAnalysisPipelineTestCase3.class,
+            SequenceIntegrationTests.SequenceAnalysisPipelineTestCase1.class,
+            SequenceIntegrationTests.SequenceAnalysisPipelineTestCase2.class,
+            OutputIntegrationTests.VariantProcessingTest.class,
+            SequenceRemoteIntegrationTests.class,
+            SequenceTriggerHelper.TestCase.class,
+            SequencePipelineServiceImpl.TestCase.class
+        );
     }
 
     @Override
-    @NotNull
-    public Set<Class> getUnitTests()
+    public @NotNull Set<Class<?>> getUnitTests()
     {
-        return PageFlowUtil.set(
-                SequenceAlignmentTask.TestCase.class,
-                SequenceAnalysisManager.TestCase.class,
-                SequenceJob.TestCase.class,
-                SequenceJobSupportImpl.TestCase.class,
-                ProcessVariantsHandler.TestCase.class,
-                VariantProcessingJob.TestCase.class,
-                ScatterGatherUtils.TestCase.class,
-                ChainFileValidator.TestCase.class,
-                FastqcRunner.TestCase.class
+        return Set.of(
+            SequenceAlignmentTask.TestCase.class,
+            SequenceAnalysisManager.TestCase.class,
+            SequenceJob.TestCase.class,
+            SequenceJobSupportImpl.TestCase.class,
+            ProcessVariantsHandler.TestCase.class,
+            VariantProcessingJob.TestCase.class,
+            ScatterGatherUtils.TestCase.class,
+            ChainFileValidator.TestCase.class,
+            FastqcRunner.TestCase.class
         );
     }
 

--- a/Studies/src/org/labkey/studies/StudiesModule.java
+++ b/Studies/src/org/labkey/studies/StudiesModule.java
@@ -14,7 +14,6 @@ import org.labkey.api.studies.StudiesService;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.studies.query.StudiesUserSchema;
 import org.labkey.api.studies.security.StudiesDataAdminRole;
-import org.labkey.studies.query.StudiesUserSchema;
 import org.labkey.studies.study.StudiesFilterProvider;
 import org.labkey.studies.study.StudyEnrollmentEventProvider;
 
@@ -83,10 +82,8 @@ public class StudiesModule extends ExtendedSimpleModule
     }
 
     @Override
-    public @NotNull Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
-        return PageFlowUtil.set(
-                StudiesManager.TestCase.class
-        );
+        return Set.of(StudiesManager.TestCase.class);
     }
 }

--- a/cluster/src/org/labkey/cluster/ClusterModule.java
+++ b/cluster/src/org/labkey/cluster/ClusterModule.java
@@ -122,23 +122,15 @@ public class ClusterModule extends ExtendedSimpleModule
     }
 
     @Override
-    @NotNull
-    public Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
-        @SuppressWarnings({"unchecked"})
-        Set<Class> testClasses = new HashSet<>(List.of(
-                TestCase.class
-        ));
-
-        return testClasses;
+        return Set.of(TestCase.class);
     }
 
     @Override
-    public @NotNull Set<Class> getUnitTests()
+    public @NotNull Set<Class<?>> getUnitTests()
     {
-        return new HashSet<>(List.of(
-                SlurmExecutionEngine.TestCase.class
-        ));
+        return Set.of(SlurmExecutionEngine.TestCase.class);
     }
 
     @Override

--- a/discvrcore/src/org/labkey/discvrcore/DiscvrCoreModule.java
+++ b/discvrcore/src/org/labkey/discvrcore/DiscvrCoreModule.java
@@ -87,7 +87,7 @@ public class DiscvrCoreModule extends DefaultModule
 
 
     @Override
-    public @NotNull Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
         return PageFlowUtil.set(AuditSummaryUserSchema.TestCase.class);
     }

--- a/jbrowse/src/org/labkey/jbrowse/JBrowseModule.java
+++ b/jbrowse/src/org/labkey/jbrowse/JBrowseModule.java
@@ -142,11 +142,8 @@ public class JBrowseModule extends ExtendedSimpleModule
     }
 
     @Override
-    @NotNull
-    public Set<Class> getUnitTests()
+    public @NotNull Set<Class<?>> getUnitTests()
     {
-        return PageFlowUtil.set(
-                JBrowseManager.TestCase.class
-        );
+        return Set.of(JBrowseManager.TestCase.class);
     }
 }

--- a/singlecell/src/org/labkey/singlecell/SingleCellModule.java
+++ b/singlecell/src/org/labkey/singlecell/SingleCellModule.java
@@ -310,12 +310,11 @@ public class SingleCellModule extends ExtendedSimpleModule
     }
 
     @Override
-    @NotNull
-    public Set<Class> getUnitTests()
+    public @NotNull Set<Class<?>> getUnitTests()
     {
-        return PageFlowUtil.set(
-                AbstractSingleCellHandler.TestCase.class,
-                PrepareRawCounts.TestCase.class
+        return Set.of(
+            AbstractSingleCellHandler.TestCase.class,
+            PrepareRawCounts.TestCase.class
         );
     }
 }


### PR DESCRIPTION
#### Rationale
Eliminate IntelliJ warnings caused by `Module` methods `getUnitTests()` and `getIntegrationTests()` returning raw `Set<Class>`; they now return `Set<Class<?>>`.

Also, eliminate use of the deprecated `AbstractAuditTypeProvider()` constructor and overrides of `getDomainKind()` in its subclasses; we now always call the constructor that passes in a `DomainKind`.