### PR TITLE
Continue adopting FileLike instead of File or Path

### DIFF
--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/AbstractResumer.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/AbstractResumer.java
@@ -7,6 +7,7 @@ import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.pipeline.RecordedAction;
 import org.labkey.api.sequenceanalysis.SequenceOutputFile;
 import org.labkey.api.util.Pair;
+import org.labkey.vfs.FileSystemLike;
 
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -240,7 +241,7 @@ abstract public class AbstractResumer implements Serializable
                 {
                     for (File orig : ret.getCopiedInputs().keySet())
                     {
-                        ctx.getWorkDir().inputFile(orig, ret._copiedInputs.get(orig), false);
+                        ctx.getWorkDir().inputFile(FileSystemLike.wrapFile(orig), FileSystemLike.wrapFile(ret._copiedInputs.get(orig)), false);
                     }
                 }
             }

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/AlignerIndexUtil.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/AlignerIndexUtil.java
@@ -5,6 +5,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ConvertHelper;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.pipeline.WorkDirectory;
+import org.labkey.vfs.FileSystemLike;
 
 import java.io.File;
 import java.io.IOException;
@@ -89,7 +90,7 @@ public class AlignerIndexUtil
                         if (doCopy)
                         {
                             ctx.getLogger().info("copying index files to work location");
-                            File localSharedDir = new File(wd.getDir(), "Shared");
+                            File localSharedDir = new File(wd.getDir().toNioPathForRead().toFile(), "Shared");
                             File destination = new File(localSharedDir, localName);
                             ctx.getLogger().debug(destination.getPath());
                             File[] files = webserverIndexDir.listFiles();
@@ -98,7 +99,7 @@ public class AlignerIndexUtil
                                 return false;
                             }
 
-                            destination = wd.inputFile(webserverIndexDir, destination, true);
+                            destination = wd.inputFile(FileSystemLike.wrapFile(webserverIndexDir), FileSystemLike.wrapFile(destination), true).toNioPathForRead().toFile();
                             if (output != null && !destination.equals(webserverIndexDir))
                             {
                                 ctx.getLogger().debug("adding deferred delete file: " + destination.getPath());

--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/HasJobParams.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/pipeline/HasJobParams.java
@@ -1,8 +1,8 @@
 package org.labkey.api.sequenceanalysis.pipeline;
 
 import org.json.JSONObject;
+import org.labkey.vfs.FileLike;
 
-import java.io.File;
 import java.util.Map;
 
 /**
@@ -14,5 +14,5 @@ public interface HasJobParams
 
     JSONObject getParameterJson();
 
-    File getParametersFile();
+    FileLike getParametersFile();
 }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/OutputIntegrationTests.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/OutputIntegrationTests.java
@@ -34,6 +34,7 @@ import org.labkey.api.util.TestContext;
 import org.labkey.api.view.ViewServlet;
 import org.labkey.sequenceanalysis.pipeline.ProcessVariantsHandler;
 import org.labkey.sequenceanalysis.pipeline.SequenceOutputHandlerJob;
+import org.labkey.vfs.FileLike;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.bind.annotation.RequestMethod;
 
@@ -110,15 +111,15 @@ public class OutputIntegrationTests
                 SequenceOutputHandlerJob job = (SequenceOutputHandlerJob)j;
 
                 Set<File> extraFiles = new HashSet<>();
-                extraFiles.add(new File(job.getAnalysisDirectory(), jobName + "." + outputFileId + ".log"));
-                extraFiles.add(new File(job.getAnalysisDirectory(), "sequenceOutput.json"));
-                extraFiles.add(new File(job.getAnalysisDirectory(), "sequenceSupport.json.gz"));
-                extraFiles.add(ProcessVariantsHandler.getPedigreeFile(job.getAnalysisDirectory(), "laboratory.subjects"));
-                extraFiles.add(new File(job.getAnalysisDirectory(), basename + ".gfiltered.selectVariants.annotated.filtered.vcf.gz"));
-                extraFiles.add(new File(job.getAnalysisDirectory(), basename + ".gfiltered.selectVariants.annotated.filtered.vcf.gz.tbi"));
-                extraFiles.add(new File(job.getAnalysisDirectory(), job.getBaseName() + ".pipe.xar.xml"));
+                extraFiles.add(job.getAnalysisDirectory().resolveChild(jobName + "." + outputFileId + ".log").toNioPathForRead().toFile());
+                extraFiles.add(job.getAnalysisDirectory().resolveChild("sequenceOutput.json").toNioPathForRead().toFile());
+                extraFiles.add(job.getAnalysisDirectory().resolveChild("sequenceSupport.json.gz").toNioPathForRead().toFile());
+                extraFiles.add(ProcessVariantsHandler.getPedigreeFile(job.getAnalysisDirectory(), "laboratory.subjects").toNioPathForRead().toFile());
+                extraFiles.add(job.getAnalysisDirectory().resolveChild(basename + ".gfiltered.selectVariants.annotated.filtered.vcf.gz").toNioPathForRead().toFile());
+                extraFiles.add(job.getAnalysisDirectory().resolveChild(basename + ".gfiltered.selectVariants.annotated.filtered.vcf.gz.tbi").toNioPathForRead().toFile());
+                extraFiles.add(job.getAnalysisDirectory().resolveChild(job.getBaseName() + ".pipe.xar.xml").toNioPathForRead().toFile());
 
-                verifyFileOutputs(job.getAnalysisDirectory(), extraFiles);
+                verifyFileOutputs(job.getAnalysisDirectory().toNioPathForRead().toFile(), extraFiles);
 
                 //verify outputfile created:
                 TableSelector ts = new TableSelector(ti, PageFlowUtil.set("rowid"), new SimpleFilter(FieldKey.fromString("runId/jobid/job"), job.getJobGUID()), null);

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisController.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisController.java
@@ -2145,27 +2145,24 @@ public class SequenceAnalysisController extends SpringActionController
         }
 
         @Override
-        protected File getTargetFile(String filename) throws IOException
+        protected FileLike getTargetFile(String filename) throws IOException
         {
             if (!PipelineService.get().hasValidPipelineRoot(getContainer()))
                 throw new UploadException("Pipeline root must be configured before uploading FASTA files", HttpServletResponse.SC_NOT_FOUND);
 
             PipeRoot root = PipelineService.get().getPipelineRootSetting(getContainer());
-
-            File targetDirectory = root.getRootPath();
-
-            return FileUtil.findUniqueFileName(filename, targetDirectory);
+            return FileUtil.findUniqueFileName(filename, root.getRootFileLike());
         }
 
         @Override
-        public String getResponse(ImportFastaSequencesForm form, Map<String, Pair<File, String>> files)
+        public String getResponse(ImportFastaSequencesForm form, Map<String, Pair<FileLike, String>> files)
         {
             JSONObject resp = new JSONObject();
             try
             {
-                for (Map.Entry<String, Pair<File, String>> entry : files.entrySet())
+                for (Map.Entry<String, Pair<FileLike, String>> entry : files.entrySet())
                 {
-                    File file = entry.getValue().getKey();
+                    File file = entry.getValue().getKey().toNioPathForRead().toFile();
 
                     Map<String, String> params = form.getNtParams();
                     Map<String, Object> libraryParams = form.getLibraryParams();
@@ -2444,7 +2441,7 @@ public class SequenceAnalysisController extends SpringActionController
         }
 
         @Override
-        protected File getTargetFile(String filename) throws IOException
+        protected FileLike getTargetFile(String filename) throws IOException
         {
             if (!PipelineService.get().hasValidPipelineRoot(getContainer()))
                 throw new UploadException("Pipeline root must be configured before uploading files", HttpServletResponse.SC_NOT_FOUND);
@@ -2452,7 +2449,7 @@ public class SequenceAnalysisController extends SpringActionController
             try
             {
                 FileLike targetDirectory = AssayFileWriter.ensureUploadDirectory(getContainer(), "sequenceOutputs");
-                return FileUtil.findUniqueFileName(filename, targetDirectory).toNioPathForWrite().toFile();
+                return FileUtil.findUniqueFileName(filename, targetDirectory);
             }
             catch (ExperimentException e)
             {
@@ -2461,14 +2458,14 @@ public class SequenceAnalysisController extends SpringActionController
         }
 
         @Override
-        public String getResponse(ImportOutputFileForm form, Map<String, Pair<File, String>> files)
+        public String getResponse(ImportOutputFileForm form, Map<String, Pair<FileLike, String>> files)
         {
             JSONObject resp = new JSONObject();
             try
             {
-                for (Map.Entry<String, Pair<File, String>> entry : files.entrySet())
+                for (Map.Entry<String, Pair<FileLike, String>> entry : files.entrySet())
                 {
-                    File file = entry.getValue().getKey();
+                    FileLike file = entry.getValue().getKey();
 
                     Map<String, Object> params = new CaseInsensitiveHashMap<>();
                     params.put("name", form.getName());
@@ -2577,7 +2574,7 @@ public class SequenceAnalysisController extends SpringActionController
         }
 
         @Override
-        protected File getTargetFile(String filename) throws IOException
+        protected FileLike getTargetFile(String filename) throws IOException
         {
             if (!PipelineService.get().hasValidPipelineRoot(getContainer()))
                 throw new UploadException("Pipeline root must be configured before uploading files", HttpServletResponse.SC_NOT_FOUND);
@@ -2585,7 +2582,7 @@ public class SequenceAnalysisController extends SpringActionController
             try
             {
                 FileLike targetDirectory = AssayFileWriter.ensureUploadDirectory(getContainer());
-                return FileUtil.findUniqueFileName(filename, targetDirectory).toNioPathForWrite().toFile();
+                return FileUtil.findUniqueFileName(filename, targetDirectory);
             }
             catch (ExperimentException e)
             {
@@ -2610,7 +2607,7 @@ public class SequenceAnalysisController extends SpringActionController
         }
 
         @Override
-        public String getResponse(ImportTrackForm form, Map<String, Pair<File, String>> files) throws UploadException
+        public String getResponse(ImportTrackForm form, Map<String, Pair<FileLike, String>> files) throws UploadException
         {
             JSONObject resp = new JSONObject();
             if (form.getTrackName() == null || form.getLibraryId() == null)
@@ -2620,9 +2617,9 @@ public class SequenceAnalysisController extends SpringActionController
 
             try
             {
-                for (Map.Entry<String, Pair<File, String>> entry : files.entrySet())
+                for (Map.Entry<String, Pair<FileLike, String>> entry : files.entrySet())
                 {
-                    File file = entry.getValue().getKey();
+                    File file = entry.getValue().getKey().toNioPathForRead().toFile();
 
                     try
                     {
@@ -2742,7 +2739,7 @@ public class SequenceAnalysisController extends SpringActionController
         }
 
         @Override
-        protected File getTargetFile(String filename) throws IOException
+        protected FileLike getTargetFile(String filename) throws IOException
         {
             if (!PipelineService.get().hasValidPipelineRoot(getContainer()))
                 throw new UploadException("Pipeline root must be configured before uploading files", HttpServletResponse.SC_NOT_FOUND);
@@ -2750,7 +2747,7 @@ public class SequenceAnalysisController extends SpringActionController
             try
             {
                 FileLike targetDirectory = AssayFileWriter.ensureUploadDirectory(getContainer());
-                return FileUtil.findUniqueFileName(filename, targetDirectory).toNioPathForWrite().toFile();
+                return FileUtil.findUniqueFileName(filename, targetDirectory);
             }
             catch (ExperimentException e)
             {
@@ -2759,14 +2756,14 @@ public class SequenceAnalysisController extends SpringActionController
         }
 
         @Override
-        public String getResponse(ImportChainFileForm form, Map<String, Pair<File, String>> files)
+        public String getResponse(ImportChainFileForm form, Map<String, Pair<FileLike, String>> files)
         {
             JSONObject resp = new JSONObject();
             try
             {
-                for (Map.Entry<String, Pair<File, String>> entry : files.entrySet())
+                for (Map.Entry<String, Pair<FileLike, String>> entry : files.entrySet())
                 {
-                    File file = entry.getValue().getKey();
+                    File file = entry.getValue().getKey().toNioPathForRead().toFile();
 
                     if (form.getGenomeId1() == null || form.getGenomeId2() == null)
                     {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisController.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisController.java
@@ -1876,14 +1876,14 @@ public class SequenceAnalysisController extends SpringActionController
             return getJobParameters() != null && getJobParameters().optBoolean("submitJobToReadsetContainer", false);
         }
 
-        public List<File> getFiles(PipeRoot pr) throws PipelineValidationException
+        public List<FileLike> getFiles(PipeRoot pr) throws PipelineValidationException
         {
             if (getJobParameters() == null || getJobParameters().get("inputFiles") == null)
             {
                 return null;
             }
 
-            List<File> ret = new ArrayList<>();
+            List<FileLike> ret = new ArrayList<>();
             JSONArray inputFiles = getJobParameters().getJSONArray("inputFiles");
             String path = getJobParameters().optString("path");
             for (JSONObject o : JsonUtil.toJSONObjectList(inputFiles))
@@ -1900,7 +1900,7 @@ public class SequenceAnalysisController extends SpringActionController
                         throw new PipelineValidationException("Missing file for data: " + o.get("dataId"));
                     }
 
-                    ret.add(d.getFile());
+                    ret.add(d.getFileLike());
                 }
                 else if (o.has("relPath") || o.has("fileName"))
                 {
@@ -1927,7 +1927,7 @@ public class SequenceAnalysisController extends SpringActionController
                         throw new PipelineValidationException("Unknown file: " + o.getString("relPath") + " / " + o.getString("fileName"));
                     }
 
-                    ret.add(f.toNioPathForRead().toFile());
+                    ret.add(f);
                 }
                 else if (o.opt("filePath") != null)
                 {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceIntegrationTests.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceIntegrationTests.java
@@ -1144,7 +1144,7 @@ public class SequenceIntegrationTests
 
         private File getBaseDir(PipelineJob job)
         {
-            return ((SequenceJob)job).getAnalysisDirectory();
+            return ((SequenceJob)job).getAnalysisDirectory().toNioPathForRead().toFile();
         }
 
         /**
@@ -1489,7 +1489,7 @@ public class SequenceIntegrationTests
         protected void validateAlignmentJob(Set<PipelineJob> jobs, Collection<String> additionalFiles, SequenceReadsetImpl rs, Integer aligned, Integer unaligned, boolean includeRefFiles) throws Exception
         {
             SequenceAlignmentJob job = getAlignmentJob(jobs, rs);
-            File basedir = job.getAnalysisDirectory();
+            File basedir = job.getAnalysisDirectory().toNioPathForRead().toFile();
             String outDir = SequenceTaskHelper.getUnzippedBaseName(rs.getReadDataImpl().get(0).getFile1());
 
             Set<File> expectedOutputs = new HashSet<>();
@@ -2982,7 +2982,7 @@ public class SequenceIntegrationTests
             //job1Files.add("paired1/Alignment/TestReadset1.insertsize.metrics");
             //job1Files.add("paired1/Alignment/TestReadset1.insertsize.metrics.pdf");
 
-            File basedir1 = getAlignmentJob(jobs, _readsets.get(0)).getAnalysisDirectory();
+            File basedir1 = getAlignmentJob(jobs, _readsets.get(0)).getAnalysisDirectory().toNioPathForRead().toFile();
             addOptionalFile(job1Files, basedir1, "paired1/Alignment/CpG_OB_TestReadset1.txt.gz");
             addOptionalFile(job1Files, basedir1, "paired1/Alignment/CpG_OT_TestReadset1.txt.gz");
             addOptionalFile(job1Files, basedir1, "paired1/Alignment/Non_CpG_OB_TestReadset1.bam.txt.gz");
@@ -3008,7 +3008,7 @@ public class SequenceIntegrationTests
             //job2Files.add("paired3/Alignment/TestReadset2.summary.metrics");
             //job2Files.add("paired3/Alignment/TestReadset2.insertsize.metrics");
 
-            File basedir2 = getAlignmentJob(jobs, _readsets.get(1)).getAnalysisDirectory();
+            File basedir2 = getAlignmentJob(jobs, _readsets.get(1)).getAnalysisDirectory().toNioPathForRead().toFile();
             addOptionalFile(job2Files, basedir2, "paired3/Alignment/CpG_OB_TestReadset2.txt.gz");
             addOptionalFile(job2Files, basedir2, "paired3/Alignment/CpG_OT_TestReadset2.txt.gz");
             addOptionalFile(job2Files, basedir2, "paired3/Alignment/Non_CpG_OB_TestReadset2.bam.txt.gz");
@@ -3032,7 +3032,7 @@ public class SequenceIntegrationTests
             //job3Files.add("paired4/Alignment/TestReadset3.summary.metrics");
             //job3Files.add("paired4/Alignment/TestReadset3.insertsize.metrics");
 
-            File basedir3 = getAlignmentJob(jobs, _readsets.get(2)).getAnalysisDirectory();
+            File basedir3 = getAlignmentJob(jobs, _readsets.get(2)).getAnalysisDirectory().toNioPathForRead().toFile();
             addOptionalFile(job3Files, basedir3, "paired4/Alignment/CpG_OB_TestReadset3.txt.gz");
             addOptionalFile(job3Files, basedir3, "paired4/Alignment/CpG_OT_TestReadset3.txt.gz");
             addOptionalFile(job3Files, basedir3, "paired4/Alignment/Non_CpG_OB_TestReadset3.bam.txt.gz");
@@ -3109,7 +3109,7 @@ public class SequenceIntegrationTests
             job1Files.add("paired1/Alignment/TestReadset1.insertsize.metrics");
             job1Files.add("paired1/Alignment/TestReadset1.insertsize.metrics.pdf");
 
-            File basedir1 = getAlignmentJob(jobs, _readsets.get(0)).getAnalysisDirectory();
+            File basedir1 = getAlignmentJob(jobs, _readsets.get(0)).getAnalysisDirectory().toNioPathForRead().toFile();
             addOptionalFile(job1Files, basedir1, "paired1/Alignment/CpG_OB_TestReadset1.txt.gz");
             addOptionalFile(job1Files, basedir1, "paired1/Alignment/CpG_OT_TestReadset1.txt.gz");
             addOptionalFile(job1Files, basedir1, "paired1/Alignment/Non_CpG_OB_TestReadset1.bam.txt.gz");
@@ -3132,7 +3132,7 @@ public class SequenceIntegrationTests
             job2Files.add("paired3/Alignment/TestReadset2.summary.metrics");
             //job2Files.add("paired3/Alignment/TestReadset2.insertsize.metrics");
 
-            File basedir2 = getAlignmentJob(jobs, _readsets.get(1)).getAnalysisDirectory();
+            File basedir2 = getAlignmentJob(jobs, _readsets.get(1)).getAnalysisDirectory().toNioPathForRead().toFile();
             addOptionalFile(job2Files, basedir2, "paired3/Alignment/CpG_OB_TestReadset2.txt.gz");
             addOptionalFile(job2Files, basedir2, "paired3/Alignment/CpG_OT_TestReadset2.txt.gz");
             addOptionalFile(job2Files, basedir2, "paired3/Alignment/Non_CpG_OB_TestReadset2.bam.txt.gz");
@@ -3154,7 +3154,7 @@ public class SequenceIntegrationTests
             job3Files.add("paired4/Alignment/TestReadset3.summary.metrics");
             //job3Files.add("paired4/Alignment/TestReadset3.insertsize.metrics");
 
-            File basedir3 = getAlignmentJob(jobs, _readsets.get(2)).getAnalysisDirectory();
+            File basedir3 = getAlignmentJob(jobs, _readsets.get(2)).getAnalysisDirectory().toNioPathForRead().toFile();
             addOptionalFile(job3Files, basedir3, "paired4/Alignment/CpG_OB_TestReadset3.txt.gz");
             addOptionalFile(job3Files, basedir3, "paired4/Alignment/CpG_OT_TestReadset3.txt.gz");
             addOptionalFile(job3Files, basedir3, "paired4/Alignment/Non_CpG_OB_TestReadset3.bam.txt.gz");

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequencePipelineServiceImpl.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequencePipelineServiceImpl.java
@@ -514,7 +514,7 @@ public class SequencePipelineServiceImpl extends SequencePipelineService
             return null;
         }
 
-        return ((SequenceJob) job).getInputFiles();
+        return ((SequenceJob) job).getInputFiles().stream().map(f -> f.toNioPathForRead().toFile()).toList();
     }
 
     @Override

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/AlignmentMetricsHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/AlignmentMetricsHandler.java
@@ -90,7 +90,7 @@ public class AlignmentMetricsHandler extends AbstractParameterizedOutputHandler<
             }
 
             List<File> bams = new ArrayList<>();
-            bams.addAll(job.getJobSupport(FileAnalysisJobSupport.class).getInputFiles());
+            bams.addAll(job.getJobSupport(FileAnalysisJobSupport.class).getInputFiles().stream().map(f -> f.toNioPathForRead().toFile()).toList());
             if (bams.isEmpty())
             {
                 job.error("No BAMS found, aborting");

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/LiftoverHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/analysis/LiftoverHandler.java
@@ -226,7 +226,7 @@ public class LiftoverHandler implements SequenceOutputHandler<SequenceOutputHand
             action.addInput(f.getFile(), "Input File");
             action.addInput(chainFile, "Chain File");
 
-            File outDir = ((FileAnalysisJobSupport) job).getAnalysisDirectory();
+            File outDir = ((FileAnalysisJobSupport) job).getAnalysisDirectory().toNioPathForRead().toFile();
             String baseName = SequenceAnalysisService.get().getUnzippedBaseName(f.getFile().getName());
             File lifted = new File(outDir, baseName + ".lifted-" + targetGenomeId + getOutputExtension(f.getFile()));
             File unmappedOutput = retainUnmapped ? getUnmappedOutputFile(lifted) : null;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentAnalysisJob.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentAnalysisJob.java
@@ -20,6 +20,7 @@ import org.labkey.sequenceanalysis.SequenceAnalysisServiceImpl;
 import org.labkey.sequenceanalysis.SequenceReadsetImpl;
 import org.labkey.sequenceanalysis.model.AnalysisModelImpl;
 import org.labkey.sequenceanalysis.util.SequenceUtil;
+import org.labkey.vfs.FileSystemLike;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -104,7 +105,7 @@ public class AlignmentAnalysisJob extends SequenceJob
 
             AlignmentAnalysisJob j = new AlignmentAnalysisJob(targetContainer, u, jobName, pr, params, model);
             j.setDescription(description);
-            j.setInputFiles(Collections.singletonList(model.getAlignmentFileObject()));
+            j.setInputFiles(Collections.singletonList(FileSystemLike.wrapFile(model.getAlignmentFileObject())));
 
             ret.add(j);
         }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentAnalysisRemoteWorkTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentAnalysisRemoteWorkTask.java
@@ -16,6 +16,7 @@ import org.labkey.api.sequenceanalysis.pipeline.ReferenceGenome;
 import org.labkey.api.sequenceanalysis.pipeline.SequencePipelineService;
 import org.labkey.api.util.FileType;
 import org.labkey.sequenceanalysis.run.util.FastaIndexer;
+import org.labkey.vfs.FileLike;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -111,8 +112,9 @@ public class AlignmentAnalysisRemoteWorkTask extends WorkDirectoryTask<Alignment
         Map<String, AnalysisModel> alignmentMap = getAnalysisMap();
 
         List<AnalysisStep.Output> outputs = new ArrayList<>();
-        for (File inputBam : getTaskHelper().getSupport().getInputFiles())
+        for (FileLike inputFileLike : getTaskHelper().getSupport().getInputFiles())
         {
+            File inputBam = inputFileLike.toNioPathForRead().toFile();
             AnalysisModel m = alignmentMap.get(inputBam.getName());
             if (m == null)
             {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentAnalysisWorkTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentAnalysisWorkTask.java
@@ -65,10 +65,9 @@ public class AlignmentAnalysisWorkTask extends WorkDirectoryTask<AlignmentAnalys
         }
 
         @Override
-        public PipelineJob.Task createTask(PipelineJob job)
+        public AlignmentAnalysisWorkTask createTask(PipelineJob job)
         {
-            AlignmentAnalysisWorkTask task = new AlignmentAnalysisWorkTask(this, job);
-            return task;
+            return new AlignmentAnalysisWorkTask(this, job);
         }
 
         @Override
@@ -124,7 +123,7 @@ public class AlignmentAnalysisWorkTask extends WorkDirectoryTask<AlignmentAnalys
             throw new PipelineJobException("Unable to find reference FASTA for analysis: " + getPipelineJob().getAnalyisId());
         }
 
-        File outDir = new File(getTaskHelper().getJob().getAnalysisDirectory(), FileUtil.getBaseName(m.getAlignmentFileObject()));
+        File outDir = getTaskHelper().getJob().getAnalysisDirectory().resolveChild(FileUtil.getBaseName(m.getAlignmentFileObject())).toNioPathForRead().toFile();
         if (!outDir.exists())
         {
             outDir.mkdirs();

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentImportJob.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentImportJob.java
@@ -14,8 +14,8 @@ import org.labkey.api.security.User;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.sequenceanalysis.SequenceAnalysisModule;
 import org.labkey.sequenceanalysis.util.SequenceUtil;
+import org.labkey.vfs.FileLike;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
@@ -39,7 +39,7 @@ public class AlignmentImportJob extends SequenceJob
         super(SequencePipelineProvider.NAME, c, u, jobName, root, params, new TaskId(FileAnalysisTaskPipeline.class, NAME), FOLDER_NAME);
     }
 
-    public static List<AlignmentImportJob> create(Container c, User u, String jobName, String description, JSONObject params, Collection<File> inputFiles) throws IOException, PipelineValidationException
+    public static List<AlignmentImportJob> create(Container c, User u, String jobName, String description, JSONObject params, Collection<FileLike> inputFiles) throws IOException, PipelineValidationException
     {
         PipeRoot pr = PipelineService.get().findPipelineRoot(c);
         if (pr == null || !pr.isValid())

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentInitTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentInitTask.java
@@ -14,6 +14,7 @@ import org.labkey.api.sequenceanalysis.pipeline.PipelineStepCtx;
 import org.labkey.api.sequenceanalysis.pipeline.ReferenceLibraryStep;
 import org.labkey.api.sequenceanalysis.pipeline.SequencePipelineService;
 import org.labkey.api.util.FileType;
+import org.labkey.vfs.FileSystemLike;
 
 import java.io.File;
 import java.util.Collections;
@@ -136,13 +137,13 @@ public class AlignmentInitTask extends WorkDirectoryTask<AlignmentInitTask.Facto
             }
             else
             {
-                getHelper().getFileManager().addInput(action, "Job Parameters", getHelper().getJob().getParametersFile());
+                getHelper().getFileManager().addInput(action, "Job Parameters", FileSystemLike.toFile(getHelper().getJob().getParametersFile()));
                 getJob().getLogger().info("Creating Reference Library FASTA");
 
                 ReferenceLibraryStep step = steps.get(0).getProvider().create(getHelper());
 
                 //ensure the FASTA exists
-                File sharedDirectory = new File(getHelper().getJob().getAnalysisDirectory(), SequenceTaskHelper.SHARED_SUBFOLDER_NAME);
+                File sharedDirectory = FileSystemLike.toFile(getHelper().getJob().getAnalysisDirectory().resolveChild(SequenceTaskHelper.SHARED_SUBFOLDER_NAME));
                 if (!sharedDirectory.exists())
                 {
                     sharedDirectory.mkdirs();

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentNormalizationTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/AlignmentNormalizationTask.java
@@ -27,6 +27,8 @@ import org.labkey.sequenceanalysis.run.util.BuildBamIndexWrapper;
 import org.labkey.sequenceanalysis.run.util.CollectInsertSizeMetricsWrapper;
 import org.labkey.sequenceanalysis.run.util.CollectWgsMetricsWrapper;
 import org.labkey.sequenceanalysis.util.SequenceUtil;
+import org.labkey.vfs.FileLike;
+import org.labkey.vfs.FileSystemLike;
 
 import java.io.File;
 import java.io.IOException;
@@ -111,10 +113,10 @@ public class AlignmentNormalizationTask extends WorkDirectoryTask<AlignmentNorma
             //move and make sure BAMs are coordinate sorted and indexed
             FileType bamFile = new FileType("bam");
             Map<String, File> bamMap = new HashMap<>();
-            for (File f : getTaskHelper().getJob().getInputFiles())
+            for (FileLike f : getTaskHelper().getJob().getInputFiles())
             {
                 getJob().getLogger().debug("input file: " + f.getPath());
-                bamMap.put(f.getName(), f);
+                bamMap.put(f.getName(), FileSystemLike.toFile(f));
             }
 
 
@@ -195,7 +197,7 @@ public class AlignmentNormalizationTask extends WorkDirectoryTask<AlignmentNorma
                 getTaskHelper().getFileManager().addInput(moveAction, "Input BAM", bam);
                 actions.add(moveAction);
 
-                File finalDestination = new File(getTaskHelper().getJob().getAnalysisDirectory(), originalFile.getName());
+                File finalDestination = FileSystemLike.toFile(getTaskHelper().getJob().getAnalysisDirectory().resolveChild(originalFile.getName()));
                 if (TaskFileManager.InputFileTreatment.leaveInPlace == getTaskHelper().getFileManager().getInputFileTreatment())
                 {
                     if (bam.equals(originalFile))

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/CacheAlignerIndexesTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/CacheAlignerIndexesTask.java
@@ -18,6 +18,7 @@ import org.labkey.api.sequenceanalysis.pipeline.ReferenceGenomeManager;
 import org.labkey.api.sequenceanalysis.pipeline.SequencePipelineService;
 import org.labkey.api.util.FileType;
 import org.labkey.sequenceanalysis.run.util.FastaIndexer;
+import org.labkey.vfs.FileSystemLike;
 
 import java.io.File;
 import java.io.IOException;
@@ -122,19 +123,20 @@ public class CacheAlignerIndexesTask extends WorkDirectoryTask<CacheAlignerIndex
         //pre-cache aligner indexes
         for (PipelineStepProvider<AlignmentStep> provider : SequencePipelineService.get().getProviders(AlignmentStep.class))
         {
-            if (provider instanceof AbstractAlignmentStepProvider)
+            if (provider instanceof AbstractAlignmentStepProvider<?> aasp)
             {
-                if (((AbstractAlignmentStepProvider)provider).isAlwaysCacheIndex())
+                if (aasp.isAlwaysCacheIndex())
                 {
                     getJob().getLogger().info("preparing index for: " + provider.getName());
                     AlignmentStep alignmentStep = provider.create(ctx);
 
                     boolean hasIndex = AlignerIndexUtil.hasCachedIndex(alignmentStep.getPipelineCtx(), alignmentStep.getIndexCachedDirName(getJob()), referenceGenome);
-                    File outDir = new File(_wd.getDir(), alignmentStep.getIndexCachedDirName(getJob()));
+                    File dir = FileSystemLike.toFile(_wd.getDir());
+                    File outDir = new File(dir, alignmentStep.getIndexCachedDirName(getJob()));
                     if (!hasIndex)
                     {
                         //create locally first
-                        alignmentStep.createIndex(referenceGenome, _wd.getDir());
+                        alignmentStep.createIndex(referenceGenome, dir);
 
                         //NOTE: the AlignerSteps are doing this themselves.  not sure if that is the right behavior
                         if (!AlignerIndexUtil.hasCachedIndex(ctx, provider.getName(), referenceGenome))

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/CacheAlignerIndexesTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/CacheAlignerIndexesTask.java
@@ -17,6 +17,7 @@ import org.labkey.api.sequenceanalysis.pipeline.ReferenceGenome;
 import org.labkey.api.sequenceanalysis.pipeline.ReferenceGenomeManager;
 import org.labkey.api.sequenceanalysis.pipeline.SequencePipelineService;
 import org.labkey.api.util.FileType;
+import org.labkey.api.util.FileUtil;
 import org.labkey.sequenceanalysis.run.util.FastaIndexer;
 import org.labkey.vfs.FileSystemLike;
 
@@ -132,7 +133,7 @@ public class CacheAlignerIndexesTask extends WorkDirectoryTask<CacheAlignerIndex
 
                     boolean hasIndex = AlignerIndexUtil.hasCachedIndex(alignmentStep.getPipelineCtx(), alignmentStep.getIndexCachedDirName(getJob()), referenceGenome);
                     File dir = FileSystemLike.toFile(_wd.getDir());
-                    File outDir = new File(dir, alignmentStep.getIndexCachedDirName(getJob()));
+                    File outDir = FileUtil.appendName(dir, alignmentStep.getIndexCachedDirName(getJob()));
                     if (!hasIndex)
                     {
                         //create locally first

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/CreateReferenceLibraryTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/CreateReferenceLibraryTask.java
@@ -293,7 +293,7 @@ public class CreateReferenceLibraryTask extends PipelineJob.Task<CreateReference
             getPipelineJob().setLibraryId(rowId);
 
             String basename = FileUtil.makeLegalName(rowId + "_" + getPipelineJob().getLibraryName().replace(" ", "_"));
-            File outputDir = new File(getPipelineJob().getAnalysisDirectory(), rowId.toString());
+            File outputDir = getPipelineJob().getAnalysisDirectory().resolveChild(rowId.toString()).toNioPathForRead().toFile();
             if (!outputDir.exists())
             {
                 outputDir.mkdirs();

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/IlluminaImportJob.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/IlluminaImportJob.java
@@ -15,8 +15,8 @@ import org.labkey.api.security.User;
 import org.labkey.api.util.FileType;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.sequenceanalysis.SequenceAnalysisModule;
+import org.labkey.vfs.FileLike;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -42,14 +42,14 @@ public class IlluminaImportJob extends SequenceJob
         super(SequencePipelineProvider.NAME, c, u, jobName, root, params, new TaskId(FileAnalysisTaskPipeline.class, NAME), FOLDER_NAME);
     }
 
-    public static List<IlluminaImportJob> create(Container c, User u, String jobName, String description, JSONObject params, Collection<File> inputFiles) throws ClassNotFoundException, IOException, PipelineValidationException
+    public static List<IlluminaImportJob> create(Container c, User u, String jobName, String description, JSONObject params, Collection<FileLike> inputFiles) throws ClassNotFoundException, IOException, PipelineValidationException
     {
         PipeRoot pr = PipelineService.get().findPipelineRoot(c);
         if (pr == null || !pr.isValid())
             throw new NotFoundException();
 
         List<IlluminaImportJob> ret = new ArrayList<>();
-        for (File csv : inputFiles)
+        for (FileLike csv : inputFiles)
         {
             IlluminaImportJob job = new IlluminaImportJob(c, u, jobName, pr, params);
             job.setDescription(description);

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/IlluminaImportTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/IlluminaImportTask.java
@@ -46,6 +46,7 @@ import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.sequenceanalysis.ReadDataImpl;
 import org.labkey.sequenceanalysis.SequenceAnalysisSchema;
+import org.labkey.vfs.FileLike;
 
 import java.io.File;
 import java.io.IOException;
@@ -131,7 +132,7 @@ public class IlluminaImportTask extends WorkDirectoryTask<IlluminaImportTask.Fac
         job.getLogger().info("Starting analysis");
         String prefix = job.getParameters().get("fastqPrefix");
 
-        List<File> inputFiles = getSupport().getInputFiles();
+        List<FileLike> inputFiles = getSupport().getInputFiles();
         if (inputFiles.isEmpty())
             throw new PipelineJobException("No input files");
 
@@ -140,7 +141,7 @@ public class IlluminaImportTask extends WorkDirectoryTask<IlluminaImportTask.Fac
         handleInstrumentRun(schema);
 
         //iterate over each CSV
-        for (File input : inputFiles)
+        for (FileLike input : inputFiles)
         {
             RecordedAction action = new RecordedAction(ACTION_NAME);
             action.addInputIfNotPresent(input, "Illumina Sample CSV");
@@ -150,9 +151,9 @@ public class IlluminaImportTask extends WorkDirectoryTask<IlluminaImportTask.Fac
             //NOTE: it might be just as easy to match filename based on expected pattern
 
             //this step will be slow
-            IlluminaFastqSplitter<Long> parser = new IlluminaFastqSplitter<>("Illumina", sampleMap, job.getLogger(), input.getParent(), prefix);
+            IlluminaFastqSplitter<Long> parser = new IlluminaFastqSplitter<>("Illumina", sampleMap, job.getLogger(), input.toNioPathForRead().toFile().getParent(), prefix);
             parser.setOutputGzip(true);
-            parser.setDestinationDir(getSupport().getAnalysisDirectory());
+            parser.setDestinationDir(getSupport().getAnalysisDirectory().toNioPathForRead().toFile());
 
             // the first element of the pair is the sample ID.  the second is either 1 or 2,
             // depending on whether the file represents the forward or reverse reads
@@ -328,10 +329,10 @@ public class IlluminaImportTask extends WorkDirectoryTask<IlluminaImportTask.Fac
         return SequenceTaskHelper.createExpData(f, getJob());
     }
 
-    private Map<String, Long> parseCsv(File sampleFile, DbSchema schema) throws PipelineJobException
+    private Map<String, Long> parseCsv(FileLike sampleFile, DbSchema schema) throws PipelineJobException
     {
         getJob().getLogger().info("Parsing Sample File: " + sampleFile.getName());
-        try (CSVReader reader = new CSVReader(Readers.getReader(sampleFile)))
+        try (CSVReader reader = new CSVReader(Readers.getReader(sampleFile.openInputStream())))
         {
             //parse the samples file
             String [] nextLine;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/JobContextImpl.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/JobContextImpl.java
@@ -11,6 +11,8 @@ import org.labkey.api.sequenceanalysis.SequenceOutputFile;
 import org.labkey.api.sequenceanalysis.pipeline.SequenceAnalysisJobSupport;
 import org.labkey.api.sequenceanalysis.pipeline.SequenceOutputHandler;
 import org.labkey.api.sequenceanalysis.pipeline.TaskFileManager;
+import org.labkey.vfs.FileLike;
+import org.labkey.vfs.FileSystemLike;
 
 import java.io.File;
 import java.util.Arrays;
@@ -29,6 +31,11 @@ public class JobContextImpl implements SequenceOutputHandler.MutableJobContext
     private final LinkedHashSet<RecordedAction> _actions = new LinkedHashSet<>();
     private TaskFileManager _fileManager;
     private final WorkDirectory _wd;
+
+    public JobContextImpl(SequenceJob job, SequenceAnalysisJobSupport support, JSONObject params, FileLike outputDir, TaskFileManager fileManager, @Nullable WorkDirectory workDirectory)
+    {
+        this(job, support, params, FileSystemLike.toFile(outputDir), fileManager, workDirectory);
+    }
 
     public JobContextImpl(SequenceJob job, SequenceAnalysisJobSupport support, JSONObject params, File outputDir, TaskFileManager fileManager, @Nullable WorkDirectory workDirectory)
     {
@@ -110,7 +117,7 @@ public class JobContextImpl implements SequenceOutputHandler.MutableJobContext
     @Override
     public File getWorkingDirectory()
     {
-        return _wd.getDir();
+        return FileSystemLike.toFile(_wd.getDir());
     }
 
     @Override

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/PrepareAlignerIndexesTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/PrepareAlignerIndexesTask.java
@@ -192,7 +192,7 @@ public class PrepareAlignerIndexesTask extends WorkDirectoryTask<PrepareAlignerI
         getJob().getLogger().debug("location of source FASTA: " + getPipelineJob().getTargetGenome().getSourceFastaFile().getPath());
 
         //NOTE: always create the index back in the local working dir, since we'll need to move it back there anyway
-        File localSharedDirectory = new File(getHelper().getJob().getAnalysisDirectory(), SequenceTaskHelper.SHARED_SUBFOLDER_NAME);
+        File localSharedDirectory = new File(getHelper().getJob().getAnalysisDirectory().toNioPathForRead().toFile(), SequenceTaskHelper.SHARED_SUBFOLDER_NAME);
         if (!localSharedDirectory.exists())
         {
             localSharedDirectory.mkdirs();

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ProcessVariantsHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ProcessVariantsHandler.java
@@ -52,6 +52,7 @@ import org.labkey.sequenceanalysis.run.util.AbstractGenomicsDBImportHandler;
 import org.labkey.sequenceanalysis.run.util.MergeVcfsAndGenotypesWrapper;
 import org.labkey.sequenceanalysis.run.variant.OutputVariantsStartingInIntervalsStep;
 import org.labkey.sequenceanalysis.util.SequenceUtil;
+import org.labkey.vfs.FileLike;
 
 import java.io.File;
 import java.io.IOException;
@@ -354,6 +355,12 @@ public class ProcessVariantsHandler implements SequenceOutputHandler<SequenceOut
     {
         providerName = FileUtil.makeLegalName(providerName);
         return new File(outputDir, providerName + ".ped");
+    }
+
+    public static FileLike getPedigreeFile(FileLike outputDir, String providerName)
+    {
+        providerName = FileUtil.makeLegalName(providerName);
+        return outputDir.resolveChild(providerName + ".ped");
     }
 
     public static List<Interval> getIntervals(JobContext ctx)
@@ -730,7 +737,7 @@ public class ProcessVariantsHandler implements SequenceOutputHandler<SequenceOut
         @Override
         public void complete(JobContext ctx, List<SequenceOutputFile> inputs, List<SequenceOutputFile> outputsCreated) throws PipelineJobException
         {
-            SequenceTaskHelper taskHelper = new SequenceTaskHelper(getPipelineJob(ctx.getJob()), getPipelineJob(ctx.getJob()).getDataDirectory());
+            SequenceTaskHelper taskHelper = new SequenceTaskHelper(getPipelineJob(ctx.getJob()), getPipelineJob(ctx.getJob()).getDataDirectory().toNioPathForRead().toFile());
             List<PipelineStepCtx<VariantProcessingStep>> providers = SequencePipelineService.get().getSteps(ctx.getJob(), VariantProcessingStep.class);
             for (PipelineStepCtx<VariantProcessingStep> stepCtx : providers)
             {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ReadsetImportJob.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ReadsetImportJob.java
@@ -26,8 +26,8 @@ import org.labkey.api.view.NotFoundException;
 import org.labkey.sequenceanalysis.SequenceAnalysisModule;
 import org.labkey.sequenceanalysis.SequenceReadsetImpl;
 import org.labkey.sequenceanalysis.util.NucleotideSequenceFileType;
+import org.labkey.vfs.FileLike;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -55,7 +55,7 @@ public class ReadsetImportJob extends SequenceJob
     {
     }
 
-    public static List<ReadsetImportJob> create(Container c, User u, String jobName, String description, JSONObject params, List<File> inputFiles) throws PipelineJobException, IOException, PipelineValidationException
+    public static List<ReadsetImportJob> create(Container c, User u, String jobName, String description, JSONObject params, List<FileLike> inputFiles) throws PipelineJobException, IOException, PipelineValidationException
     {
         Map<Container, PipeRoot> containerToPipeRootMap = new HashMap<>();
 
@@ -137,7 +137,7 @@ public class ReadsetImportJob extends SequenceJob
                     job.getLogger().debug("job was submitted to an alternate folder: " + targetContainer.getPath());
                 }
 
-                List<File> inputFilesSubset = new ArrayList<>();
+                List<FileLike> inputFilesSubset = new ArrayList<>();
                 JSONArray files = fileGroup.getJSONArray("files");
                 for (int i = 0; i < files.length(); i++)
                 {
@@ -165,7 +165,7 @@ public class ReadsetImportJob extends SequenceJob
         }
     }
 
-    private static File findFile(JSONObject file, List<File> inputFiles)
+    private static FileLike findFile(JSONObject file, List<FileLike> inputFiles)
     {
         if (!file.isNull("dataId") && StringUtils.trimToNull(file.get("dataId").toString()) != null)
         {
@@ -178,7 +178,7 @@ public class ReadsetImportJob extends SequenceJob
                     throw new IllegalArgumentException("Unable to find file with ID: " + file.getInt("dataId"));
                 }
 
-                return d.getFile();
+                return d.getFileLike();
             }
             catch (ConversionException | NullPointerException e)
             {
@@ -187,7 +187,7 @@ public class ReadsetImportJob extends SequenceJob
         }
         else if (!file.isNull("fileName") && StringUtils.trimToNull(file.getString("fileName")) != null)
         {
-            List<File> hits = new ArrayList<>();
+            List<FileLike> hits = new ArrayList<>();
             inputFiles.forEach(x -> {
                 if (x.getName().equals(file.getString("fileName")))
                 {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ReadsetInitTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ReadsetInitTask.java
@@ -39,6 +39,7 @@ import org.labkey.sequenceanalysis.SequenceReadsetImpl;
 import org.labkey.sequenceanalysis.model.BarcodeModel;
 import org.labkey.sequenceanalysis.util.FastqUtils;
 import org.labkey.sequenceanalysis.util.NucleotideSequenceFileType;
+import org.labkey.vfs.FileLike;
 
 import java.io.File;
 import java.io.IOException;
@@ -147,7 +148,7 @@ public class ReadsetInitTask extends WorkDirectoryTask<ReadsetInitTask.Factory>
 
         getJob().getLogger().info("Preparing to import sequence data");
         getJob().getLogger().info("input files:");
-        for (File input : getPipelineJob().getInputFiles())
+        for (FileLike input : getPipelineJob().getInputFiles())
         {
             getJob().getLogger().info(input.getPath());
         }
@@ -280,7 +281,7 @@ public class ReadsetInitTask extends WorkDirectoryTask<ReadsetInitTask.Factory>
         if (!gz.isType(f))
         {
             getJob().getLogger().info("\tcompressing input file: " + f.getName());
-            output = new File(getHelper().getJob().getAnalysisDirectory(), f.getName() + ".gz");
+            output = new File(getHelper().getJob().getAnalysisDirectory().toNioPathForRead().toFile(), f.getName() + ".gz");
             //note: the non-compressed file will potentially be deleted during cleanup, depending on the selection for input handling
             Compress.compressGzip(f, output);
         }
@@ -293,7 +294,7 @@ public class ReadsetInitTask extends WorkDirectoryTask<ReadsetInitTask.Factory>
             }
             else
             {
-                output = new File(getHelper().getJob().getAnalysisDirectory(), f.getName());
+                output = new File(getHelper().getJob().getAnalysisDirectory().toNioPathForRead().toFile(), f.getName());
                 if (!output.exists())
                 {
                     if (getHelper().getFileManager().getInputFileTreatment() == TaskFileManager.InputFileTreatment.delete || getHelper().getFileManager().getInputFileTreatment() == TaskFileManager.InputFileTreatment.compress)
@@ -352,13 +353,12 @@ public class ReadsetInitTask extends WorkDirectoryTask<ReadsetInitTask.Factory>
 
     public static File getExtraBarcodesFile(SequenceTaskHelper helper)
     {
-        return new File(helper.getJob().getAnalysisDirectory(), "extraBarcodes.txt");
+        return helper.getJob().getAnalysisDirectory().resolveChild("extraBarcodes.txt").toNioPathForRead().toFile();
     }
 
     public static Set<File> handleInputs(SequenceJob job, TaskFileManager.InputFileTreatment inputFileTreatment, Collection<RecordedAction> actions, Set<File> outputFiles, @Nullable Set<File> unalteredInputs) throws PipelineJobException
     {
-        Set<File> inputs = new HashSet<>();
-        inputs.addAll(job.getInputFiles());
+        Set<File> inputs = new HashSet<>(job.getInputFiles().stream().map(f -> f.toNioPathForRead().toFile()).toList());
 
         job.getLogger().info("Cleaning up input files");
 
@@ -451,7 +451,7 @@ public class ReadsetInitTask extends WorkDirectoryTask<ReadsetInitTask.Factory>
         try
         {
             //NOTE: we assume the input is gzipped already
-            File outputDir = job.getAnalysisDirectory();
+            File outputDir = job.getAnalysisDirectory().toNioPathForRead().toFile();
             File output = new File(outputDir, input.getName());
             job.getLogger().debug("Destination: " + output.getPath());
             boolean alreadyMoved = false;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ReferenceLibraryPipelineJob.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/ReferenceLibraryPipelineJob.java
@@ -109,7 +109,7 @@ public class ReferenceLibraryPipelineJob extends SequenceJob
 
     public File getSerializedLibraryMembersFile()
     {
-        return FileUtil.appendName(getDataDirectory(), FileUtil.getBaseName(getLogFile()) + ".json");
+        return getDataDirectory().resolveChild(FileUtil.getBaseName(getLogFile()) + ".json").toNioPathForRead().toFile();
     }
 
     //for recreating an existing library

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceAlignmentJob.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceAlignmentJob.java
@@ -21,8 +21,9 @@ import org.labkey.sequenceanalysis.SequenceAnalysisModule;
 import org.labkey.sequenceanalysis.SequenceAnalysisServiceImpl;
 import org.labkey.sequenceanalysis.SequenceReadsetImpl;
 import org.labkey.sequenceanalysis.util.SequenceUtil;
+import org.labkey.vfs.FileLike;
+import org.labkey.vfs.FileSystemLike;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -74,7 +75,7 @@ public class SequenceAlignmentJob extends SequenceJob
             SequenceAlignmentJob j = new SequenceAlignmentJob(targetContainer, u, jobName, pr, params, readset);
             j.setDescription(description);
 
-            List<File> inputFiles = new ArrayList<>();
+            List<FileLike> inputFiles = new ArrayList<>();
             for (ReadData rd : readset.getReadData())
             {
                 if (rd.getFileId1() != null)
@@ -86,7 +87,7 @@ public class SequenceAlignmentJob extends SequenceJob
                     }
                     else
                     {
-                        inputFiles.add(d1.getFile());
+                        inputFiles.add(FileSystemLike.wrapFile(d1.getFile()));
                     }
                 }
 
@@ -99,7 +100,7 @@ public class SequenceAlignmentJob extends SequenceJob
                     }
                     else
                     {
-                        inputFiles.add(d2.getFile());
+                        inputFiles.add(FileSystemLike.wrapFile(d2.getFile()));
                     }
                 }
             }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceAlignmentTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceAlignmentTask.java
@@ -87,6 +87,7 @@ import org.labkey.sequenceanalysis.run.util.MergeSamFilesWrapper;
 import org.labkey.sequenceanalysis.util.FastqMerger;
 import org.labkey.sequenceanalysis.util.FastqUtils;
 import org.labkey.sequenceanalysis.util.SequenceUtil;
+import org.labkey.vfs.FileLike;
 
 import java.io.File;
 import java.io.IOException;
@@ -440,39 +441,32 @@ public class SequenceAlignmentTask extends WorkDirectoryTask<SequenceAlignmentTa
         }
         else if (doCopy)
         {
-            try
-            {
-                RecordedAction action = new RecordedAction(COPY_REFERENCE_LIBRARY_ACTIONNAME);
-                Date start = new Date();
-                action.setStartTime(start);
+            RecordedAction action = new RecordedAction(COPY_REFERENCE_LIBRARY_ACTIONNAME);
+            Date start = new Date();
+            action.setStartTime(start);
 
-                String basename = FileUtil.getBaseName(refFasta);
-                File targetDir = new File(_wd.getDir(), "Shared");
-                for (File f : refFasta.getParentFile().listFiles())
+            String basename = FileUtil.getBaseName(refFasta);
+            File targetDir = new File(_wd.getDir().toNioPathForRead().toFile(), "Shared");
+            for (File f : refFasta.getParentFile().listFiles())
+            {
+                if (f.getName().startsWith(basename))
                 {
-                    if (f.getName().startsWith(basename))
-                    {
-                        getJob().getLogger().debug("copying reference file: " + f.getPath());
-                        File movedFile = _wd.inputFile(f, new File(targetDir, f.getName()), true);
-                        copiedInputs.put(f, movedFile);
-                        action.addInputIfNotPresent(f, "Reference File");
-                        action.addOutputIfNotPresent(movedFile, "Copied Reference File", true);
-                    }
+                    getJob().getLogger().debug("copying reference file: " + f.getPath());
+                    File movedFile = _wd.inputFile(f, new File(targetDir, f.getName()), true);
+                    copiedInputs.put(f, movedFile);
+                    action.addInputIfNotPresent(f, "Reference File");
+                    action.addOutputIfNotPresent(movedFile, "Copied Reference File", true);
                 }
-
-                Date end = new Date();
-                action.setEndTime(end);
-                getJob().getLogger().info("Copy Reference Duration: " + DurationFormatUtils.formatDurationWords(end.getTime() - start.getTime(), true, true));
-                actions.add(action);
-
-                referenceGenome.setWorkingFasta(new File(targetDir, refFasta.getName()));
-
-                getTaskFileManagerImpl().addIntermediateFile(targetDir);
             }
-            catch (IOException e)
-            {
-                throw new PipelineJobException(e);
-            }
+
+            Date end = new Date();
+            action.setEndTime(end);
+            getJob().getLogger().info("Copy Reference Duration: " + DurationFormatUtils.formatDurationWords(end.getTime() - start.getTime(), true, true));
+            actions.add(action);
+
+            referenceGenome.setWorkingFasta(new File(targetDir, refFasta.getName()));
+
+            getTaskFileManagerImpl().addIntermediateFile(targetDir);
         }
         else
         {
@@ -1507,16 +1501,16 @@ public class SequenceAlignmentTask extends WorkDirectoryTask<SequenceAlignmentTa
 
         private Resumer(SequenceAlignmentTask task)
         {
-            super(task.getPipelineJob().getAnalysisDirectory(), task.getJob().getLogger(), task.getHelper().getFileManager());
+            super(task.getPipelineJob().getAnalysisDirectory().toNioPathForRead().toFile(), task.getJob().getLogger(), task.getHelper().getFileManager());
         }
 
         public static Resumer create(SequenceAlignmentJob job, SequenceAlignmentTask task) throws PipelineJobException
         {
             //NOTE: allow a file in either local working dir or webserver dir.  if both exist, use the file most recently modified
             File file = null;
-            for (File dir : Arrays.asList(job.getAnalysisDirectory(), task._wd.getDir()))
+            for (FileLike dir : Arrays.asList(job.getAnalysisDirectory(), task._wd.getDir()))
             {
-                File toCheck = getSerializedJson(dir, JSON_NAME);
+                File toCheck = getSerializedJson(dir.toNioPathForRead().toFile(), JSON_NAME);
                 if (toCheck.exists())
                 {
                     job.getLogger().debug("inspecting file: " + toCheck.getPath());
@@ -1554,23 +1548,16 @@ public class SequenceAlignmentTask extends WorkDirectoryTask<SequenceAlignmentTa
             Resumer ret = readFromJson(file, Resumer.class);
             ret._isResume = true;
             ret.setLogger(task.getJob().getLogger());
-            ret.setWebserverJobDir(task.getPipelineJob().getAnalysisDirectory());
+            ret.setWebserverJobDir(task.getPipelineJob().getAnalysisDirectory().toNioPathForRead().toFile());
             ret.getFileManager().onResume(job, task._wd);
 
             task._taskHelper.setFileManager(ret.getFileManager());
-            try
+            if (!ret._copiedInputs.isEmpty())
             {
-                if (!ret._copiedInputs.isEmpty())
+                for (File orig : ret._copiedInputs.keySet())
                 {
-                    for (File orig : ret._copiedInputs.keySet())
-                    {
-                        task._wd.inputFile(orig, ret._copiedInputs.get(orig), false);
-                    }
+                    task._wd.inputFile(orig, ret._copiedInputs.get(orig), false);
                 }
-            }
-            catch (IOException e)
-            {
-                throw new PipelineJobException(e);
             }
 
             //debugging:

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceAnalysisTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceAnalysisTask.java
@@ -149,7 +149,7 @@ public class SequenceAnalysisTask extends WorkDirectoryTask<SequenceAnalysisTask
         SequenceTaskHelper taskHelper = new SequenceTaskHelper(getPipelineJob(), _wd);
 
         //we dont delete the resume file during the alignment task, since we've had issues w/ JMS dropping messages and needing to repeat that whole task
-        File xmlFile = SequenceAlignmentTask.Resumer.getSerializedJson(getPipelineJob().getAnalysisDirectory(), SequenceAlignmentTask.Resumer.JSON_NAME);
+        File xmlFile = SequenceAlignmentTask.Resumer.getSerializedJson(getPipelineJob().getAnalysisDirectory().toNioPathForRead().toFile(), SequenceAlignmentTask.Resumer.JSON_NAME);
         if (xmlFile.exists())
         {
             xmlFile.delete();

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceConcatTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceConcatTask.java
@@ -93,7 +93,7 @@ public class SequenceConcatTask extends PipelineJob.Task<SequenceConcatTask.Fact
 
         try
         {
-            createConcatenatedSequence(sequenceIds, getPipelineJob().getParameterJson().getString("sequenceName"), getPipelineJob().getParameterJson().getString("sequenceDescription"), getJob().getContainer(), getJob().getUser(), getPipelineJob().getAnalysisDirectory());
+            createConcatenatedSequence(sequenceIds, getPipelineJob().getParameterJson().getString("sequenceName"), getPipelineJob().getParameterJson().getString("sequenceDescription"), getJob().getContainer(), getJob().getUser(), getPipelineJob().getAnalysisDirectory().toNioPathForRead().toFile());
         }
         catch (IOException e)
         {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceJob.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceJob.java
@@ -51,7 +51,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -73,7 +72,7 @@ public class SequenceJob extends PipelineJob implements FileAnalysisJobSupport, 
     private FileLike _webserverJobDir;
     private FileLike _parentWebserverJobDir;
     private String _folderPrefix;
-    private List<File> _inputFiles;
+    private List<FileLike> _inputFiles;
     private List<SequenceOutputFile> _outputsToCreate = new ArrayList<>();
     private PipeRoot _folderFileRoot;
     private Collection<String> _dockerVolumes;
@@ -172,13 +171,13 @@ public class SequenceJob extends PipelineJob implements FileAnalysisJobSupport, 
         return PipelineJobService.get().getTaskPipeline(_taskPipelineId);
     }
 
-    protected void setInputFiles(Collection<File> inputs)
+    protected void setInputFiles(Collection<FileLike> inputs)
     {
         _inputFiles = inputs == null ? Collections.emptyList() : new ArrayList<>(inputs);
     }
 
     @Override
-    public List<File> getInputFiles()
+    public List<FileLike> getInputFiles()
     {
         return _inputFiles == null ? Collections.emptyList() : Collections.unmodifiableList(_inputFiles);
     }
@@ -237,7 +236,7 @@ public class SequenceJob extends PipelineJob implements FileAnalysisJobSupport, 
 
     protected void writeParameters(JSONObject params) throws IOException
     {
-        try (PrintWriter writer = PrintWriters.getPrintWriter(getParametersFile()))
+        try (PrintWriter writer = PrintWriters.getPrintWriter(getParametersFile().openOutputStream()))
         {
             writer.write(params.isEmpty() ? "" : params.toString(1));
         }
@@ -256,10 +255,10 @@ public class SequenceJob extends PipelineJob implements FileAnalysisJobSupport, 
         {
             try
             {
-                File paramFile = getParametersFile();
+                File paramFile = getParametersFile().toNioPathForRead().toFile();
                 if (paramFile.exists())
                 {
-                    try (BufferedReader reader = Readers.getReader(getParametersFile()))
+                    try (BufferedReader reader = Readers.getReader(getParametersFile().openInputStream()))
                     {
                         List<String> lines = IOUtils.readLines(reader);
 
@@ -341,7 +340,7 @@ public class SequenceJob extends PipelineJob implements FileAnalysisJobSupport, 
     }
 
     @Override
-    public FileLike getDataDirectoryFileLike()
+    public FileLike getDataDirectory()
     {
         return _webserverJobDir;
     }
@@ -359,26 +358,26 @@ public class SequenceJob extends PipelineJob implements FileAnalysisJobSupport, 
     }
 
     @Override
-    public File getAnalysisDirectory()
+    public FileLike getAnalysisDirectory()
     {
-        return _webserverJobDir.toNioPathForWrite().toFile();
+        return _webserverJobDir;
     }
 
     @Override
-    public File findOutputFile(String name)
-    {
-        return findFile(name);
-    }
-
-    @Override
-    public File findInputFile(String name)
+    public FileLike findOutputFile(String name)
     {
         return findFile(name);
     }
 
+    @Override
+    public FileLike findInputFile(String name)
+    {
+        return findFile(name);
+    }
+
 
     @Override
-    public File findOutputFile(@NotNull String outputDir, @NotNull String fileName)
+    public FileLike findOutputFile(@NotNull String outputDir, @NotNull String fileName)
     {
         return AbstractFileAnalysisJob.getOutputFile(outputDir, fileName, getPipeRoot(), getLogger(), getAnalysisDirectory());
     }
@@ -390,10 +389,10 @@ public class SequenceJob extends PipelineJob implements FileAnalysisJobSupport, 
     }
 
     @Override
-    public File getParametersFile()
+    public FileLike getParametersFile()
     {
         var dir = _parentWebserverJobDir == null ? _webserverJobDir : _parentWebserverJobDir;
-        return FileUtil.appendName(dir.toNioPathForWrite().toFile(),_folderPrefix + ".json");
+        return dir.resolveFile(org.labkey.api.util.Path.parse(_folderPrefix + ".json"));
     }
 
     @Override
@@ -559,9 +558,9 @@ public class SequenceJob extends PipelineJob implements FileAnalysisJobSupport, 
         _experimentRunRowId = experimentRunRowId;
     }
 
-    public File findFile(String name)
+    public FileLike findFile(String name)
     {
-        return FileUtil.appendName(getAnalysisDirectory(), name);
+        return getAnalysisDirectory().resolveChild(name);
     }
 
     protected static XarGeneratorFactorySettings getXarGenerator() throws CloneNotSupportedException
@@ -613,7 +612,7 @@ public class SequenceJob extends PipelineJob implements FileAnalysisJobSupport, 
             SequenceJob job = new SequenceJob();
             job._support = new SequenceJobSupportImpl();
             job._support.cacheExpData(d1);
-            job.setLogFile(FileUtil.appendName(FileUtil.getTempDirectory(), "testJob.log").toPath());
+            job.setLogFile(FileUtil.getTempDirectoryFileLike().resolveChild("testJob.log"));
 
             File testFile = FileUtil.appendName(FileUtil.getTempDirectory(), "testJob.json.txt");
             File support = job.getCachedSupportFile();
@@ -655,7 +654,7 @@ public class SequenceJob extends PipelineJob implements FileAnalysisJobSupport, 
 
         if (localDir == null)
         {
-            ret = FileUtil.appendName(wd.getDir(), "cachedData");
+            ret = FileUtil.appendName(wd.getDir().toNioPathForRead().toFile(), "cachedData");
         }
         else
         {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceNormalizationTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceNormalizationTask.java
@@ -365,7 +365,8 @@ public class SequenceNormalizationTask extends WorkDirectoryTask<SequenceNormali
 
                         if (fp.file2 != null)
                         {
-                            localCopy = _wd.getWorkingCopyForInput(FileSystemLike.wrapFile(fp.file2)).toNioPathForRead().toFile();
+                            localCopyFileLike = _wd.getWorkingCopyForInput(FileSystemLike.wrapFile(fp.file2));
+                            localCopy = localCopyFileLike == null ? null : localCopyFileLike.toNioPathForRead().toFile();
                             if (localCopy != null)
                             {
                                 getJob().getLogger().debug("using local working copy for file: " + fp.file2.getPath());

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceNormalizationTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceNormalizationTask.java
@@ -55,6 +55,8 @@ import org.labkey.sequenceanalysis.util.FastqMerger;
 import org.labkey.sequenceanalysis.util.FastqUtils;
 import org.labkey.sequenceanalysis.util.NucleotideSequenceFileType;
 import org.labkey.sequenceanalysis.util.SequenceUtil;
+import org.labkey.vfs.FileLike;
+import org.labkey.vfs.FileSystemLike;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -164,16 +166,16 @@ public class SequenceNormalizationTask extends WorkDirectoryTask<SequenceNormali
         return (ReadsetImportJob)getJob();
     }
 
-    private static List<File> getFilesToNormalize(PipelineJob job, List<File> files, boolean allowMissingFiles) throws FileNotFoundException
+    private static List<File> getFilesToNormalize(PipelineJob job, List<FileLike> files, boolean allowMissingFiles) throws FileNotFoundException
     {
         SequencePipelineSettings settings = new SequencePipelineSettings(job.getParameters());
         if (settings.isDoBarcode())
         {
-            return files;
+            return files.stream().map(f -> f.toNioPathForRead().toFile()).toList();
         }
 
         List<File> toNormalize = new ArrayList<>();
-        for (File f : files)
+        for (FileLike f : files)
         {
             if (!f.exists())
             {
@@ -184,7 +186,7 @@ public class SequenceNormalizationTask extends WorkDirectoryTask<SequenceNormali
             }
 
             if (isNormalizationRequired(job, f))
-                toNormalize.add(f);
+                toNormalize.add(f.toNioPathForRead().toFile());
         }
 
         try
@@ -230,7 +232,7 @@ public class SequenceNormalizationTask extends WorkDirectoryTask<SequenceNormali
         return toNormalize;
     }
 
-    private static boolean isNormalizationRequired(PipelineJob job, File f)
+    private static boolean isNormalizationRequired(PipelineJob job, FileLike f)
     {
         try
         {
@@ -249,7 +251,7 @@ public class SequenceNormalizationTask extends WorkDirectoryTask<SequenceNormali
 
                 try
                 {
-                    if (!SequenceUtil.hasMinLineCount(f, 4))
+                    if (!SequenceUtil.hasMinLineCount(f.toNioPathForRead().toFile(), 4))
                     {
                         job.getLogger().warn("file has fewer than 4 lines: " + f.getPath());
                         return false;
@@ -261,7 +263,7 @@ public class SequenceNormalizationTask extends WorkDirectoryTask<SequenceNormali
                 }
 
                 QualityEncodingDetector detector = new QualityEncodingDetector();
-                try (FastqReader reader = new FastqReader(f))
+                try (FastqReader reader = new FastqReader(f.toNioPathForRead().toFile()))
                 {
                     detector.add(QualityEncodingDetector.DEFAULT_MAX_RECORDS_TO_ITERATE * 10, reader);
                 }
@@ -316,7 +318,7 @@ public class SequenceNormalizationTask extends WorkDirectoryTask<SequenceNormali
         List<RecordedAction> actions = new ArrayList<>();
 
         getJob().getLogger().info("Starting Normalization Task");
-        File normalizationDir = new File(_wd.getDir(), SequenceTaskHelper.NORMALIZATION_SUBFOLDER_NAME);
+        File normalizationDir = new File(_wd.getDir().toNioPathForRead().toFile(), SequenceTaskHelper.NORMALIZATION_SUBFOLDER_NAME);
         normalizationDir.mkdirs();
 
         try
@@ -333,7 +335,7 @@ public class SequenceNormalizationTask extends WorkDirectoryTask<SequenceNormali
                 {
                     for (FileGroup.FilePair fp : lane)
                     {
-                        File localCopy = _wd.getWorkingCopyForInput(fp.file1);
+                        File localCopy = _wd.getWorkingCopyForInput(FileSystemLike.wrapFile(fp.file1)).toNioPathForRead().toFile();
                         if (localCopy != null)
                         {
                             getJob().getLogger().debug("using local working copy for file: " + fp.file1.getPath());
@@ -362,7 +364,7 @@ public class SequenceNormalizationTask extends WorkDirectoryTask<SequenceNormali
 
                         if (fp.file2 != null)
                         {
-                            localCopy = _wd.getWorkingCopyForInput(fp.file2);
+                            localCopy = _wd.getWorkingCopyForInput(FileSystemLike.wrapFile(fp.file2)).toNioPathForRead().toFile();
                             if (localCopy != null)
                             {
                                 getJob().getLogger().debug("using local working copy for file: " + fp.file2.getPath());
@@ -634,7 +636,7 @@ public class SequenceNormalizationTask extends WorkDirectoryTask<SequenceNormali
             }
 
             //add final action for later tracking based on role
-            File baseDirectory = new File(_wd.getDir(), SequenceTaskHelper.NORMALIZATION_SUBFOLDER_NAME);
+            File baseDirectory = new File(_wd.getDir().toNioPathForRead().toFile(), SequenceTaskHelper.NORMALIZATION_SUBFOLDER_NAME);
             baseDirectory.mkdirs();
 
             Set<File> finalOutputs = ReadsetInitTask.handleInputs(getPipelineJob(), getHelper().getFileManager().getInputFileTreatment(), actions, _finalOutputs, null);
@@ -880,7 +882,7 @@ public class SequenceNormalizationTask extends WorkDirectoryTask<SequenceNormali
 
         getJob().getLogger().info("\tFile format: " + type.getPrimaryExtension());
 
-        File baseDirectory = new File(_wd.getDir(), SequenceTaskHelper.NORMALIZATION_SUBFOLDER_NAME);
+        File baseDirectory = new File(_wd.getDir().toNioPathForWrite().toFile(), SequenceTaskHelper.NORMALIZATION_SUBFOLDER_NAME);
         baseDirectory.mkdirs();
 
         File workingDir = new File(baseDirectory, basename);

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceNormalizationTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceNormalizationTask.java
@@ -335,7 +335,8 @@ public class SequenceNormalizationTask extends WorkDirectoryTask<SequenceNormali
                 {
                     for (FileGroup.FilePair fp : lane)
                     {
-                        File localCopy = _wd.getWorkingCopyForInput(FileSystemLike.wrapFile(fp.file1)).toNioPathForRead().toFile();
+                        FileLike localCopyFileLike = _wd.getWorkingCopyForInput(FileSystemLike.wrapFile(fp.file1));
+                        File localCopy = localCopyFileLike == null ? null : localCopyFileLike.toNioPathForRead().toFile();
                         if (localCopy != null)
                         {
                             getJob().getLogger().debug("using local working copy for file: " + fp.file1.getPath());

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceOutputHandlerFinalTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceOutputHandlerFinalTask.java
@@ -151,7 +151,7 @@ public class SequenceOutputHandlerFinalTask extends PipelineJob.Task<SequenceOut
         }
 
         //run final handler
-        TaskFileManagerImpl manager = new TaskFileManagerImpl(getPipelineJob(), getPipelineJob().getAnalysisDirectory(), null);
+        TaskFileManagerImpl manager = new TaskFileManagerImpl(getPipelineJob(), getPipelineJob().getAnalysisDirectory().toNioPathForRead().toFile(), null);
         JobContextImpl ctx = new JobContextImpl(getPipelineJob(), getPipelineJob().getSequenceSupport(), getPipelineJob().getParameterJson(), getPipelineJob().getAnalysisDirectory(), manager, null);
         getPipelineJob().getHandler().getProcessor().complete(ctx, getPipelineJob().getFiles(), outputsCreated);
 

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceOutputHandlerInitTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceOutputHandlerInitTask.java
@@ -131,7 +131,7 @@ public class SequenceOutputHandlerInitTask extends PipelineJob.Task<SequenceOutp
             }
         }
 
-        TaskFileManagerImpl manager = new TaskFileManagerImpl(getPipelineJob(), getPipelineJob().getAnalysisDirectory(), null);
+        TaskFileManagerImpl manager = new TaskFileManagerImpl(getPipelineJob(), getPipelineJob().getAnalysisDirectory().toNioPathForRead().toFile(), null);
         JobContextImpl ctx = new JobContextImpl(getPipelineJob(), getPipelineJob().getSequenceSupport(), getPipelineJob().getParameterJson(), getPipelineJob().getAnalysisDirectory(), manager, null);
         handler.getProcessor().init(ctx, getPipelineJob().getFiles(), actions, outputsToCreate);
 

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceOutputHandlerJob.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceOutputHandlerJob.java
@@ -18,6 +18,8 @@ import org.labkey.api.sequenceanalysis.pipeline.SequenceOutputHandler;
 import org.labkey.api.util.FileUtil;
 import org.labkey.sequenceanalysis.SequenceAnalysisManager;
 import org.labkey.sequenceanalysis.util.SequenceUtil;
+import org.labkey.vfs.FileLike;
+import org.labkey.vfs.FileSystemLike;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -164,7 +166,7 @@ public class SequenceOutputHandlerJob extends SequenceJob implements HasJobParam
             return new File(getWebserverDir(true), logName + ".outputs.json.gz");
         }
 
-        return new File(getDataDirectory(), FileUtil.getBaseName(getLogFile()) + ".outputs.json.gz");
+        return getDataDirectory().resolveChild(FileUtil.getBaseName(getLogFile()) + ".outputs.json.gz").toNioPathForRead().toFile();
     }
 
     @Override
@@ -199,14 +201,14 @@ public class SequenceOutputHandlerJob extends SequenceJob implements HasJobParam
     }
 
     @Override
-    public List<File> getInputFiles()
+    public List<FileLike> getInputFiles()
     {
         try
         {
-            List<File> ret = new ArrayList<>();
+            List<FileLike> ret = new ArrayList<>();
             for (SequenceOutputFile o : getFiles())
             {
-                ret.add(o.getFile());
+                ret.add(FileSystemLike.wrapFile(o.getFile()));
             }
 
             return ret;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceOutputHandlerWebserverTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceOutputHandlerWebserverTask.java
@@ -106,7 +106,7 @@ public class SequenceOutputHandlerWebserverTask extends PipelineJob.Task<Sequenc
             getJob().getLogger().warn("there are no sequence output files to process, this is probably an error");
         }
 
-        handler.getProcessor().processFilesOnWebserver(getJob(), getPipelineJob().getSequenceSupport(), getPipelineJob().getFiles(), getPipelineJob().getParameterJson(), getPipelineJob().getAnalysisDirectory(), actions, outputsToCreate);
+        handler.getProcessor().processFilesOnWebserver(getJob(), getPipelineJob().getSequenceSupport(), getPipelineJob().getFiles(), getPipelineJob().getParameterJson(), getPipelineJob().getAnalysisDirectory().toNioPathForRead().toFile(), actions, outputsToCreate);
 
         if (!outputsToCreate.isEmpty())
         {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequencePipelineSettings.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequencePipelineSettings.java
@@ -31,8 +31,9 @@ import org.labkey.api.util.JsonUtil;
 import org.labkey.sequenceanalysis.FileGroup;
 import org.labkey.sequenceanalysis.SequenceReadsetImpl;
 import org.labkey.sequenceanalysis.model.BarcodeModel;
+import org.labkey.vfs.FileLike;
+import org.labkey.vfs.FileSystemLike;
 
-import java.io.File;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -130,12 +131,12 @@ public class SequencePipelineSettings
             if (json.has("file1"))
             {
                 JSONObject fileJson = json.getJSONObject("file1");
-                p.file1 = resolveFile(fileJson, job, allowMissingFiles);
+                p.file1 = FileSystemLike.toFile(resolveFile(fileJson, job, allowMissingFiles));
             }
 
             if (json.has("file2"))
             {
-                p.file2 = resolveFile(json.getJSONObject("file2"), job, allowMissingFiles);
+                p.file2 = FileSystemLike.toFile(resolveFile(json.getJSONObject("file2"), job, allowMissingFiles));
             }
 
             fg.filePairs.add(p);
@@ -209,7 +210,7 @@ public class SequencePipelineSettings
         return model;
     }
 
-    private File resolveFile(JSONObject json, @Nullable SequenceJob job, boolean allowMissingFiles)
+    private FileLike resolveFile(JSONObject json, @Nullable SequenceJob job, boolean allowMissingFiles)
     {
         if (json.has("dataId"))
         {
@@ -224,14 +225,14 @@ public class SequencePipelineSettings
                         throw new IllegalArgumentException("Unable to find ExpData: " + json.get("dataId"));
                     }
 
-                    return d.getFile();
+                    return d.getFileLike();
                 }
                 else
                 {
                     if (job != null && job.getSequenceSupport().getCachedData(dataId) != null)
                     {
                         job.getLogger().debug("found using cached ExpData");
-                        return job.getSequenceSupport().getCachedData(dataId);
+                        return FileSystemLike.wrapFile(job.getSequenceSupport().getCachedData(dataId));
                     }
                 }
             }
@@ -242,7 +243,7 @@ public class SequencePipelineSettings
             //resolve based on inputs
             if (job != null)
             {
-                for (File input : job.getJobSupport(FileAnalysisJobSupport.class).getInputFiles())
+                for (FileLike input : job.getJobSupport(FileAnalysisJobSupport.class).getInputFiles())
                 {
                     if (input.getName().equals(json.getString("fileName")))
                     {
@@ -253,7 +254,7 @@ public class SequencePipelineSettings
                         else
                         {
                             //file might have been a copied input, check in analysis directory
-                            File test = new File(job.getJobSupport(FileAnalysisJobSupport.class).getAnalysisDirectory(), input.getName());
+                            FileLike test = job.getJobSupport(FileAnalysisJobSupport.class).getAnalysisDirectory().resolveChild(input.getName());
                             if (test.exists())
                             {
                                 return test;
@@ -268,7 +269,7 @@ public class SequencePipelineSettings
         {
             job.getLogger().error("unable to find file: " + json + ", active task: " + job.getActiveTaskId().getName(), new Exception());
             job.getLogger().debug("input files were: ");
-            for (File f : job.getJobSupport(FileAnalysisJobSupport.class).getInputFiles())
+            for (FileLike f : job.getJobSupport(FileAnalysisJobSupport.class).getInputFiles())
             {
                 job.getLogger().debug("[" + f.getPath() + "], exists: " + f.exists());
             }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceReadsetHandlerInitTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceReadsetHandlerInitTask.java
@@ -119,7 +119,7 @@ public class SequenceReadsetHandlerInitTask extends PipelineJob.Task<SequenceRea
             }
         }
 
-        handler.getProcessor().init(getJob(), getPipelineJob().getSequenceSupport(), getPipelineJob().getReadsets(), getPipelineJob().getParameterJson(), getPipelineJob().getAnalysisDirectory(), actions, outputsToCreate);
+        handler.getProcessor().init(getJob(), getPipelineJob().getSequenceSupport(), getPipelineJob().getReadsets(), getPipelineJob().getParameterJson(), getPipelineJob().getAnalysisDirectory().toNioPathForRead().toFile(), actions, outputsToCreate);
 
         if (!outputsToCreate.isEmpty())
         {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceReadsetHandlerJob.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceReadsetHandlerJob.java
@@ -14,8 +14,9 @@ import org.labkey.api.sequenceanalysis.pipeline.HasJobParams;
 import org.labkey.api.sequenceanalysis.pipeline.SequenceOutputHandler;
 import org.labkey.sequenceanalysis.SequenceAnalysisManager;
 import org.labkey.sequenceanalysis.SequenceReadsetImpl;
+import org.labkey.vfs.FileLike;
+import org.labkey.vfs.FileSystemLike;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -74,23 +75,23 @@ public class SequenceReadsetHandlerJob extends SequenceJob implements HasJobPara
     }
 
     @Override
-    public List<File> getInputFiles()
+    public List<FileLike> getInputFiles()
     {
         try
         {
-            List<File> ret = new ArrayList<>();
+            List<FileLike> ret = new ArrayList<>();
             for (Readset rs : getReadsets())
             {
                 for (ReadData d : rs.getReadData())
                 {
                     if (d.getFile1() != null)
                     {
-                        ret.add(d.getFile1());
+                        ret.add(FileSystemLike.wrapFile(d.getFile1()));
                     }
 
                     if (d.getFile2() != null)
                     {
-                        ret.add(d.getFile2());
+                        ret.add(FileSystemLike.wrapFile(d.getFile2()));
                     }
                 }
             }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceReadsetHandlerRemoteTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceReadsetHandlerRemoteTask.java
@@ -100,7 +100,7 @@ public class SequenceReadsetHandlerRemoteTask extends WorkDirectoryTask<Sequence
     public RecordedActionSet run() throws PipelineJobException
     {
         SequenceOutputHandler<SequenceOutputHandler.SequenceReadsetProcessor> handler = getPipelineJob().getHandler();
-        JobContextImpl ctx = new JobContextImpl(getPipelineJob(), getPipelineJob().getSequenceSupport(), getPipelineJob().getParameterJson(), _wd.getDir(), new TaskFileManagerImpl(getPipelineJob(), _wd.getDir(), _wd), _wd);
+        JobContextImpl ctx = new JobContextImpl(getPipelineJob(), getPipelineJob().getSequenceSupport(), getPipelineJob().getParameterJson(), _wd.getDir().toNioPathForRead().toFile(), new TaskFileManagerImpl(getPipelineJob(), _wd.getDir().toNioPathForRead().toFile(), _wd), _wd);
 
         getJob().setStatus(PipelineJob.TaskStatus.running, "Running: " + handler.getName());
         handler.getProcessor().processFilesRemote(getPipelineJob().getReadsets(), ctx);

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceReadsetHandlerWebserverTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceReadsetHandlerWebserverTask.java
@@ -51,7 +51,7 @@ public class SequenceReadsetHandlerWebserverTask extends PipelineJob.Task<Sequen
         public List<String> getProtocolActionNames()
         {
             List<String> allowableNames = new ArrayList<>();
-            for (SequenceOutputHandler handler : SequenceAnalysisServiceImpl.get().getFileHandlers(SequenceOutputHandler.TYPE.Readset))
+            for (SequenceOutputHandler<?> handler : SequenceAnalysisServiceImpl.get().getFileHandlers(SequenceOutputHandler.TYPE.Readset))
             {
                 allowableNames.add(handler.getName());
             }
@@ -75,7 +75,7 @@ public class SequenceReadsetHandlerWebserverTask extends PipelineJob.Task<Sequen
         }
 
         @Override
-        public PipelineJob.Task createTask(PipelineJob job)
+        public SequenceReadsetHandlerWebserverTask createTask(PipelineJob job)
         {
             return new SequenceReadsetHandlerWebserverTask(this, job);
         }
@@ -106,7 +106,7 @@ public class SequenceReadsetHandlerWebserverTask extends PipelineJob.Task<Sequen
             getJob().getLogger().warn("there are no sequence output files to process, this is probably an error");
         }
 
-        handler.getProcessor().processFilesOnWebserver(getJob(), getPipelineJob().getSequenceSupport(), getPipelineJob().getReadsets(), getPipelineJob().getParameterJson(), getPipelineJob().getAnalysisDirectory(), actions, outputsToCreate);
+        handler.getProcessor().processFilesOnWebserver(getJob(), getPipelineJob().getSequenceSupport(), getPipelineJob().getReadsets(), getPipelineJob().getParameterJson(), getPipelineJob().getAnalysisDirectory().toNioPathForRead().toFile(), actions, outputsToCreate);
 
         if (!outputsToCreate.isEmpty())
         {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceTaskHelper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/SequenceTaskHelper.java
@@ -93,7 +93,7 @@ public class SequenceTaskHelper implements PipelineContext
     {
         _job = job;
         _wd = wd;
-        _workLocation = workLocation == null ? wd.getDir() : workLocation;  //TODO: is this the right behavior??
+        _workLocation = workLocation == null ? wd.getDir().toNioPathForRead().toFile() : workLocation;  //TODO: is this the right behavior??
         _fileManager = new TaskFileManagerImpl(_job, getWorkingDirectory(), wd);
         _settings = new SequencePipelineSettings(_job.getParameters());
     }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/TaskFileManagerImpl.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/TaskFileManagerImpl.java
@@ -36,6 +36,8 @@ import org.labkey.api.writer.PrintWriters;
 import org.labkey.sequenceanalysis.SequenceAnalysisManager;
 import org.labkey.sequenceanalysis.SequenceAnalysisSchema;
 import org.labkey.sequenceanalysis.util.SequenceUtil;
+import org.labkey.vfs.FileLike;
+import org.labkey.vfs.FileSystemLike;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -79,6 +81,11 @@ public class TaskFileManagerImpl implements TaskFileManager, Serializable
 
     }
 
+    public TaskFileManagerImpl(SequenceJob job, FileLike workDir, WorkDirectory wd)
+    {
+        this(job, workDir.toNioPathForRead().toFile(), wd);
+    }
+
     public TaskFileManagerImpl(SequenceJob job, File workDir, WorkDirectory wd)
     {
         _job = job;
@@ -95,7 +102,7 @@ public class TaskFileManagerImpl implements TaskFileManager, Serializable
         }
 
         _job = (SequenceJob)job;
-        _workLocation = wd.getDir();
+        _workLocation = wd.getDir().toNioPathForRead().toFile();
         _wd = wd;
     }
 
@@ -243,7 +250,7 @@ public class TaskFileManagerImpl implements TaskFileManager, Serializable
 
     private File getDeferredDeleteLog(boolean create)
     {
-        File logFile = new File(getSupport().getAnalysisDirectory(), "toDelete.txt");
+        File logFile = new File(getSupport().getAnalysisDirectory().toNioPathForRead().toFile(), "toDelete.txt");
         if (create && !logFile.exists())
         {
             try
@@ -262,7 +269,7 @@ public class TaskFileManagerImpl implements TaskFileManager, Serializable
 
     private File getMetricsLog(boolean create)
     {
-        File logFile = new File(getSupport().getAnalysisDirectory(), "metricsToCreate.txt");
+        File logFile = new File(getSupport().getAnalysisDirectory().toNioPathForRead().toFile(), "metricsToCreate.txt");
         if (create && !logFile.exists())
         {
             try (PrintWriter writer = PrintWriters.getPrintWriter(logFile))
@@ -381,7 +388,7 @@ public class TaskFileManagerImpl implements TaskFileManager, Serializable
         File f = new File(_workLocation, line);
         if (!f.exists())
         {
-            File test = new File(getSupport().getAnalysisDirectory(), line);
+            File test = new File(getSupport().getAnalysisDirectory().toNioPathForRead().toFile(), line);
             if (test.exists())
             {
                 f = test;
@@ -521,7 +528,7 @@ public class TaskFileManagerImpl implements TaskFileManager, Serializable
             metricLog = getMetricsLog(true);
             try (BufferedWriter writer = new BufferedWriter(new FileWriter(metricLog, true)))
             {
-                String bamRelPath = mf.getInputFile() == null ? "" : FilenameUtils.normalize(_wd.getRelativePath(mf.getInputFile()));
+                String bamRelPath = mf.getInputFile() == null ? "" : FilenameUtils.normalize(_wd.getRelativePath(FileSystemLike.wrapFile(mf.getInputFile())));
                 String type = mf.getType() == null ? "" : mf.getType().name();
 
                 List<Map<String, Object>> metricLines = PicardMetricsUtil.processFile(mf.getMetricFile(), _job.getLogger());
@@ -724,9 +731,9 @@ public class TaskFileManagerImpl implements TaskFileManager, Serializable
     private Set<String> getInputPaths()
     {
         Set<String> inputPaths = new HashSet<>();
-        for (File f : getSupport().getInputFiles())
+        for (FileLike f : getSupport().getInputFiles())
         {
-            inputPaths.add(f.getPath());
+            inputPaths.add(f.toNioPathForRead().toFile().getPath());
         }
         return inputPaths;
     }
@@ -910,7 +917,7 @@ public class TaskFileManagerImpl implements TaskFileManager, Serializable
 
                 //NOTE: preserving relative locations is a pain.  therefore we copy all outputs, including directories
                 //then sort out which files were specified as named outputs later
-                for (File input : _wd.getDir().listFiles())
+                for (File input : _wd.getDir().toNioPathForRead().toFile().listFiles())
                 {
                     if (input.getName().matches("^core.[0-9]+$") || input.getName().endsWith(".hprof"))
                     {
@@ -979,8 +986,8 @@ public class TaskFileManagerImpl implements TaskFileManager, Serializable
             return;
         }
 
-        String path = _wd.getRelativePath(input);
-        File dest = new File(getSupport().getAnalysisDirectory(), path);
+        String path = _wd.getRelativePath(FileSystemLike.wrapFile(input));
+        File dest = new File(getSupport().getAnalysisDirectory().toNioPathForRead().toFile(), path);
         _job.getLogger().debug("to: " + dest.getPath());
 
         boolean doMove = true;
@@ -1018,7 +1025,7 @@ public class TaskFileManagerImpl implements TaskFileManager, Serializable
                 Files.delete(input.toPath());
             }
 
-            dest = _wd.outputFile(input, dest);
+            dest = _wd.outputFile(FileSystemLike.wrapFile(input), FileSystemLike.wrapFile(dest)).toNioPathForRead().toFile();
             processCopiedFile(input, dest, actions, resumer);
         }
     }
@@ -1048,7 +1055,6 @@ public class TaskFileManagerImpl implements TaskFileManager, Serializable
     @Override
     public void decompressInputFiles(Pair<File, File> pair, List<RecordedAction> actions)
     {
-        List<File> list = new ArrayList<>();
         if (pair.first != null)
             pair.first = decompressFile(pair.first, actions);
         if (pair.second != null)
@@ -1070,7 +1076,7 @@ public class TaskFileManagerImpl implements TaskFileManager, Serializable
             //NOTE: we use relative paths in all cases here
             _job.getLogger().info("Decompressing file: " + i.getPath());
 
-            unzipped = new File(_wd.getDir(), i.getName().replaceAll(".gz$", ""));
+            unzipped = new File(_wd.getDir().toNioPathForRead().toFile(), i.getName().replaceAll(".gz$", ""));
             unzipped = Compress.decompressGzip(i, unzipped);
             _job.getLogger().debug("\tunzipped: " + unzipped.getPath());
 

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/VariantProcessingJob.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/VariantProcessingJob.java
@@ -270,7 +270,7 @@ public class VariantProcessingJob extends SequenceOutputHandlerJob
 
     private File getJobToIntervalFile()
     {
-        return new File(isSplitJob() ? getDataDirectory().getParentFile() : getDataDirectory(), "jobsToInterval.txt");
+        return new File(isSplitJob() ? getDataDirectory().getParent().toNioPathForRead().toFile() : getDataDirectory().toNioPathForRead().toFile(), "jobsToInterval.txt");
     }
 
     private void writeJobToIntervalMap(Map<String, List<Interval>> jobToIntervalMap) throws IOException
@@ -410,7 +410,7 @@ public class VariantProcessingJob extends SequenceOutputHandlerJob
         {
             VariantProcessingJob job1 = new VariantProcessingJob(){
                 @Override
-                public FileLike getDataDirectoryFileLike()
+                public FileLike getDataDirectory()
                 {
                     return FileSystemLike.wrapFile(new File(System.getProperty("java.io.tmpdir")));
                 }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/VariantProcessingRemoteMergeTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/VariantProcessingRemoteMergeTask.java
@@ -109,7 +109,8 @@ public class VariantProcessingRemoteMergeTask extends WorkDirectoryTask<VariantP
     {
         SequenceTaskHelper.logModuleVersions(getJob().getLogger());
         RecordedAction action = new RecordedAction(ACTION_NAME);
-        JobContextImpl ctx = new JobContextImpl(getPipelineJob(), getPipelineJob().getSequenceSupport(), getPipelineJob().getParameterJson(), _wd.getDir(), new TaskFileManagerImpl(getPipelineJob(), _wd.getDir(), _wd), _wd);
+        File dir = _wd.getDir().toNioPathForRead().toFile();
+        JobContextImpl ctx = new JobContextImpl(getPipelineJob(), getPipelineJob().getSequenceSupport(), getPipelineJob().getParameterJson(), dir, new TaskFileManagerImpl(getPipelineJob(), dir, _wd), _wd);
 
         File finalOut;
         SequenceOutputHandler<SequenceOutputHandler.SequenceOutputProcessor> handler = getPipelineJob().getHandler();
@@ -207,7 +208,7 @@ public class VariantProcessingRemoteMergeTask extends WorkDirectoryTask<VariantP
         if (!toConcat.isEmpty())
         {
             String basename = SequenceAnalysisService.get().getUnzippedBaseName(toConcat.get(0).getName());
-            combined = new File(getPipelineJob().getAnalysisDirectory(), basename + ".vcf.gz");
+            combined = new File(getPipelineJob().getAnalysisDirectory().toNioPathForRead().toFile(), basename + ".vcf.gz");
             File combinedIdx = new File(combined.getPath() + ".tbi");
             if (combinedIdx.exists())
             {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/VariantProcessingRemoteSplitTask.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/pipeline/VariantProcessingRemoteSplitTask.java
@@ -11,6 +11,7 @@ import org.labkey.api.pipeline.WorkDirectoryTask;
 import org.labkey.api.sequenceanalysis.pipeline.SequenceOutputHandler;
 import org.labkey.api.util.FileType;
 import org.labkey.sequenceanalysis.SequenceAnalysisServiceImpl;
+import org.labkey.vfs.FileSystemLike;
 
 import java.io.File;
 import java.io.IOException;
@@ -97,7 +98,7 @@ public class VariantProcessingRemoteSplitTask extends WorkDirectoryTask<VariantP
         SequenceTaskHelper.logModuleVersions(getJob().getLogger());
 
         SequenceOutputHandler<SequenceOutputHandler.SequenceOutputProcessor> handler = getPipelineJob().getHandler();
-        JobContextImpl ctx = new JobContextImpl(getPipelineJob(), getPipelineJob().getSequenceSupport(), getPipelineJob().getParameterJson(), _wd.getDir(), new TaskFileManagerImpl(getPipelineJob(), _wd.getDir(), _wd), _wd);
+        JobContextImpl ctx = new JobContextImpl(getPipelineJob(), getPipelineJob().getSequenceSupport(), getPipelineJob().getParameterJson(), _wd.getDir().toNioPathForRead().toFile(), new TaskFileManagerImpl(getPipelineJob(), _wd.getDir().toNioPathForRead().toFile(), _wd), _wd);
 
         List<Interval> intervals = getPipelineJob().getIntervalsForTask();
         if (intervals != null)
@@ -123,10 +124,10 @@ public class VariantProcessingRemoteSplitTask extends WorkDirectoryTask<VariantP
                         ctx.getLogger().debug("No output produced, adding null to scatter outputs");
                         getPipelineJob().getScatterJobOutputs().put(getPipelineJob().getIntervalSetName(), null);
                     }
-                    else if (output.getPath().startsWith(_wd.getDir().getPath()))
+                    else if (output.getPath().startsWith(_wd.getDir().toNioPathForRead().toFile().getPath()))
                     {
                         //NOTE: the VCF will be copied back to the source dir, so translate paths
-                        String path = _wd.getRelativePath(output);
+                        String path = _wd.getRelativePath(FileSystemLike.wrapFile(output));
                         output = new File(ctx.getSourceDirectory(), path);
                         getPipelineJob().getScatterJobOutputs().put(getPipelineJob().getIntervalSetName(), output);
                     }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/SnpCountAnalysis.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/analysis/SnpCountAnalysis.java
@@ -103,7 +103,7 @@ public class SnpCountAnalysis extends AbstractPipelineStep implements AnalysisSt
             fastaIndexFile = null;
         }
 
-        File outputFile = new File(getPipelineCtx().getJob().getJobSupport(FileAnalysisJobSupport.class).getAnalysisDirectory(), FileUtil.getBaseName(inputBam) + ".snps.txt");
+        File outputFile = getPipelineCtx().getJob().getJobSupport(FileAnalysisJobSupport.class).getAnalysisDirectory().resolveChild(FileUtil.getBaseName(inputBam) + ".snps.txt").toNioPathForRead().toFile();
         SequenceReadsetImpl rs = SequenceAnalysisServiceImpl.get().getReadset(model.getReadset(), getPipelineCtx().getJob().getUser());
 
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(outputFile, true));IndexedFastaSequenceFile indexedFastaSequenceFile = new IndexedFastaSequenceFile(referenceFasta, new FastaSequenceIndex(fastaIndexFile)))

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/AbstractGenomicsDBImportHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/AbstractGenomicsDBImportHandler.java
@@ -30,10 +30,12 @@ import org.labkey.api.sequenceanalysis.pipeline.VariantProcessingStep;
 import org.labkey.api.sequenceanalysis.run.SimpleScriptWrapper;
 import org.labkey.api.util.FileType;
 import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.Path;
 import org.labkey.sequenceanalysis.ScatterGatherUtils;
 import org.labkey.sequenceanalysis.pipeline.ProcessVariantsHandler;
 import org.labkey.sequenceanalysis.pipeline.VariantProcessingJob;
 import org.labkey.sequenceanalysis.util.SequenceUtil;
+import org.labkey.vfs.FileLike;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -278,7 +280,7 @@ abstract public class AbstractGenomicsDBImportHandler extends AbstractParameteri
         job.setStatus(PipelineJob.TaskStatus.running, "Creating merged workspace from " + jobToIntervalMap.size() + " jobs");
 
         VariantProcessingJob variantProcessingJob = getPipelineJob(job);
-        File destinationWorkspace = getWorkspaceOutput(variantProcessingJob.getDataDirectory(), variantProcessingJob.getParameterJson().getString("fileBaseName"));
+        File destinationWorkspace = getWorkspaceOutput(variantProcessingJob.getDataDirectory().toNioPathForRead().toFile(), variantProcessingJob.getParameterJson().getString("fileBaseName"));
         if (!destinationWorkspace.exists())
         {
             destinationWorkspace.mkdirs();
@@ -296,7 +298,7 @@ abstract public class AbstractGenomicsDBImportHandler extends AbstractParameteri
         Map<String, File> scatterOutputs = getPipelineJob(job).getScatterJobOutputs();
         for (String name : jobToIntervalMap.keySet())
         {
-            File overallCopyDone = new File(variantProcessingJob.getDataDirectory(), name + "/copyToWebserver.done");
+            File overallCopyDone = variantProcessingJob.getDataDirectory().resolveFile(Path.parse(name + "/copyToWebserver.done")).toNioPathForRead().toFile();
             if (overallCopyDone.exists())
             {
                 overallCopyDone.delete();
@@ -342,12 +344,12 @@ abstract public class AbstractGenomicsDBImportHandler extends AbstractParameteri
 
     private Set<String> _contigsInInputs = null;
 
-    Set<String> getContigsInInputs(List<File> inputVCFs, Logger log) throws PipelineJobException
+    Set<String> getContigsInInputs(List<FileLike> inputVCFs, Logger log) throws PipelineJobException
     {
         if (_contigsInInputs == null)
         {
             Set<String> ret = new HashSet<>();
-            for (File f : inputVCFs)
+            for (FileLike f : inputVCFs)
             {
                 ret.addAll(SequenceUtil.getContigsInVcf(f));
             }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/CombineGVCFsHandler.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/CombineGVCFsHandler.java
@@ -20,6 +20,7 @@ import org.labkey.sequenceanalysis.ScatterGatherUtils;
 import org.labkey.sequenceanalysis.SequenceAnalysisModule;
 import org.labkey.sequenceanalysis.pipeline.ProcessVariantsHandler;
 import org.labkey.sequenceanalysis.pipeline.VariantProcessingJob;
+import org.labkey.vfs.FileSystemLike;
 
 import java.io.File;
 import java.io.IOException;
@@ -198,7 +199,7 @@ public class CombineGVCFsHandler extends AbstractParameterizedOutputHandler<Sequ
                     //NOTE: the VCF was copied back to the source dir, so translate paths
                     try
                     {
-                        String path = ctx.getWorkDir().getRelativePath(outputFile);
+                        String path = ctx.getWorkDir().getRelativePath(FileSystemLike.wrapFile(outputFile));
                         File movedOutputFile = new File(ctx.getSourceDirectory(), path);
                         job.getScatterJobOutputs().put(job.getIntervalSetName(), movedOutputFile);
                     }

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/GenotypeGVCFsWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/GenotypeGVCFsWrapper.java
@@ -129,7 +129,7 @@ public class GenotypeGVCFsWrapper extends AbstractGatk4Wrapper
             // If the cache directory is under the current working dir, mark to delete when done.
             // If localWorkDir is null, this indicates we're using /tmp, so also delete.
             // Otherwise this indicates a shared cache dir probably used by multiple scatter/gather jobs, and allow the merge task to do cleanup
-            boolean reportFilesForDeletion = localWorkDir == null || localWorkDir.getAbsolutePath().startsWith(ctx.getWorkDir().getDir().getAbsolutePath());
+            boolean reportFilesForDeletion = localWorkDir == null || localWorkDir.getAbsolutePath().startsWith(ctx.getWorkDir().getDir().toNioPathForRead().toFile().getAbsolutePath());
 
             if (localWorkDir == null)
             {

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/SamToFastqWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/SamToFastqWrapper.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.sequenceanalysis.run.PicardWrapper;
 import org.labkey.api.util.Pair;
+import org.labkey.vfs.FileLike;
 
 import java.io.File;
 import java.util.Arrays;
@@ -45,6 +46,11 @@ public class SamToFastqWrapper extends PicardWrapper
         execute(args);
 
         return Arrays.asList(outDir.listFiles());
+    }
+
+    public Pair<File, File> executeCommand(FileLike f, String outputName1, @Nullable String outputName2) throws PipelineJobException
+    {
+        return executeCommand(f.toNioPathForRead().toFile(), outputName1, outputName2);
     }
 
     public Pair<File, File> executeCommand(File file, String outputName1, @Nullable String outputName2) throws PipelineJobException

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/variant/SplitVcfBySamplesStep.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/variant/SplitVcfBySamplesStep.java
@@ -92,7 +92,7 @@ public class SplitVcfBySamplesStep extends AbstractCommandPipelineStep<SplitVcfB
     public void performAdditionalMergeTasks(SequenceOutputHandler.JobContext ctx, PipelineJob job, ReferenceGenome genome, List<File> orderedScatterOutputs, List<String> orderedJobDirs) throws PipelineJobException
     {
         job.getLogger().info("Merging additional track VCFs");
-        File inputVCF = ((SequenceJob)getPipelineCtx().getJob()).getInputFiles().get(0);
+        File inputVCF = ((SequenceJob)getPipelineCtx().getJob()).getInputFiles().get(0).toNioPathForRead().toFile();
         List<File> firstJobOutputs = findProducedVcfs(inputVCF, new File(ctx.getSourceDirectory(), orderedJobDirs.get(0)));
         job.getLogger().info("total VCFs found in job dir: " + firstJobOutputs.size());
         if (firstJobOutputs.isEmpty())

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/util/SequenceUtil.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/util/SequenceUtil.java
@@ -46,6 +46,7 @@ import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.writer.PrintWriters;
 import org.labkey.sequenceanalysis.run.util.BgzipRunner;
 import org.labkey.sequenceanalysis.run.variant.GatherVcfsCloudWrapper;
+import org.labkey.vfs.FileLike;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -602,7 +603,7 @@ public class SequenceUtil
         return outputGzip;
     }
 
-    public static Set<String> getContigsInVcf(File vcf) throws PipelineJobException
+    public static Set<String> getContigsInVcf(FileLike vcf) throws PipelineJobException
     {
         try
         {
@@ -610,7 +611,7 @@ public class SequenceUtil
             try (PrintWriter writer = PrintWriters.getPrintWriter(script))
             {
                 writer.println("#!/bin/bash");
-                String cat = vcf.getPath().toLowerCase().endsWith(".gz") ? "zcat" : "cat";
+                String cat = vcf.getName().toLowerCase().endsWith(".gz") ? "zcat" : "cat";
                 writer.println(cat + " '" + vcf.getPath() + "' | grep -v '#' | awk ' { print $1 } ' | sort | uniq");
             }
 

--- a/blast/src/org/labkey/blast/BLASTController.java
+++ b/blast/src/org/labkey/blast/BLASTController.java
@@ -212,13 +212,13 @@ public class BLASTController extends SpringActionController
         }
 
         @Override
-        protected File getTargetFile(String filename) throws IOException
+        protected FileLike getTargetFile(String filename) throws IOException
         {
             AssayFileWriter writer = new AssayFileWriter();
             try
             {
                 FileLike targetDirectory = AssayFileWriter.ensureUploadDirectory(getContainer());
-                return FileUtil.findUniqueFileName(filename, targetDirectory).toNioPathForWrite().toFile();
+                return FileUtil.findUniqueFileName(filename, targetDirectory);
             }
             catch (ExperimentException e)
             {
@@ -227,7 +227,7 @@ public class BLASTController extends SpringActionController
         }
 
         @Override
-        public String getResponse(RunBlastForm form, Map<String, Pair<File, String>> files)
+        public String getResponse(RunBlastForm form, Map<String, Pair<FileLike, String>> files)
         {
             JSONObject resp = new JSONObject();
             Map<String, String> params = new HashMap<>();
@@ -251,10 +251,10 @@ public class BLASTController extends SpringActionController
                 params.put("perc_identity", form.getPctIdentity());
             }
 
-            List<File> inputFiles = new ArrayList<>();
+            List<FileLike> inputFiles = new ArrayList<>();
             try
             {
-                for (Map.Entry<String, Pair<File, String>> entry : files.entrySet())
+                for (Map.Entry<String, Pair<FileLike, String>> entry : files.entrySet())
                 {
                     inputFiles.add(entry.getValue().getKey());
                 }
@@ -272,7 +272,7 @@ public class BLASTController extends SpringActionController
                         {
                             fw.write(form.getQuery());
                         }
-                        inputFiles.add(input.toNioPathForRead().toFile());
+                        inputFiles.add(input);
                     }
                     catch (ExperimentException e)
                     {
@@ -282,9 +282,9 @@ public class BLASTController extends SpringActionController
 
                 if (!inputFiles.isEmpty())
                 {
-                    for (File input : inputFiles)
+                    for (FileLike input : inputFiles)
                     {
-                        String jobId = BLASTManager.get().runBLASTN(getContainer(), getUser(), form.getDatabase(), input, form.getTask(), form.getTitle(), form.getSaveResults(), params, true);
+                        String jobId = BLASTManager.get().runBLASTN(getContainer(), getUser(), form.getDatabase(), input.toNioPathForRead().toFile(), form.getTask(), form.getTitle(), form.getSaveResults(), params, true);
                         resp.put("jobId", jobId);
                     }
                 }


### PR DESCRIPTION
#### Rationale
We can continue to strengthen our protections against path traversal attacks and start phasing out deprecated and overloaded methods that take or return Files or Paths. 

### Related Pull Requests
- https://github.com/LabKey/platform/pull/7211

#### Changes
- Eliminate some overloaded, deprecated versions of methods taking `File` or `Path`
- Convert `LocalDirectory` and `WorkDirectory` to `FileLike`
- Use `FileLike` more consistently for transform scripts