### PR TITLE
Drop redundant index

### DIFF
--- a/SequenceAnalysis/resources/schemas/dbscripts/postgresql/sequenceanalysis-12.332-12.333.sql
+++ b/SequenceAnalysis/resources/schemas/dbscripts/postgresql/sequenceanalysis-12.332-12.333.sql
@@ -1,0 +1,2 @@
+-- sequence_coverage_analysis_id [analysis_id] overlaps with sequence_coverage_ref_nt_position [analysis_id, ref_nt_id, ref_nt_position, ref_nt_insert_index]
+DROP INDEX sequenceanalysis.sequence_coverage_analysis_id;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisModule.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceAnalysisModule.java
@@ -210,7 +210,7 @@ public class SequenceAnalysisModule extends ExtendedSimpleModule
     @Override
     public Double getSchemaVersion()
     {
-        return 12.332;
+        return 12.333;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Redundant indices waste disk space and degrade insert/update/delete performance

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/7630