### PR TITLE
ProcessBuilder -> LabKeyProcessBuilder

### DIFF
--- a/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/run/AbstractCommandWrapper.java
+++ b/SequenceAnalysis/api-src/org/labkey/api/sequenceanalysis/run/AbstractCommandWrapper.java
@@ -17,12 +17,13 @@ package org.labkey.api.sequenceanalysis.run;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.pipeline.PipelineJobService;
 import org.labkey.api.sequenceanalysis.pipeline.SequencePipelineService;
+import org.labkey.api.util.LabKeyProcessBuilder;
 import org.labkey.api.util.StringUtilsLabKey;
 
 import java.io.BufferedReader;
@@ -43,7 +44,7 @@ abstract public class AbstractCommandWrapper implements CommandWrapper
 {
     private File _outputDir = null;
     private File _workingDir = null;
-    private Logger _log;
+    private final Logger _log;
     private boolean _logPath = false;
     private Level _logLevel = Level.DEBUG;
     private boolean _warnNonZeroExits = true;
@@ -105,9 +106,9 @@ abstract public class AbstractCommandWrapper implements CommandWrapper
         execute(params, redirect, null);
     }
 
-    public ProcessBuilder getProcessBuilder(List<String> params)
+    public LabKeyProcessBuilder getProcessBuilder(List<String> params)
     {
-        ProcessBuilder pb = new ProcessBuilder(params);
+        LabKeyProcessBuilder pb = new LabKeyProcessBuilder(params);
         setPath(pb);
 
         if (!_environment.isEmpty())
@@ -134,7 +135,7 @@ abstract public class AbstractCommandWrapper implements CommandWrapper
         getLogger().info("\t" + StringUtils.join(params, " "));
         _commandsExecuted.add(StringUtils.join(params, " "));
 
-        ProcessBuilder pb = getProcessBuilder(params);
+        LabKeyProcessBuilder pb = getProcessBuilder(params);
         pb.redirectErrorStream(false);
         if (redirect != null)
         {
@@ -197,7 +198,7 @@ abstract public class AbstractCommandWrapper implements CommandWrapper
         return _lastReturnCode;
     }
 
-    private void setPath(ProcessBuilder pb)
+    private void setPath(LabKeyProcessBuilder pb)
     {
         // Update PATH environment variable to make sure all files in the tools
         // directory and the directory of the executable or on the path.

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceRemoteIntegrationTests.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/SequenceRemoteIntegrationTests.java
@@ -16,6 +16,7 @@ import org.labkey.api.pipeline.TaskId;
 import org.labkey.api.pipeline.WorkDirectory;
 import org.labkey.api.reader.Readers;
 import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.LabKeyProcessBuilder;
 import org.labkey.api.writer.PrintWriters;
 import org.labkey.sequenceanalysis.pipeline.AlignmentInitTask;
 import org.labkey.sequenceanalysis.pipeline.PrepareAlignerIndexesTask;
@@ -212,7 +213,7 @@ public class SequenceRemoteIntegrationTests extends SequenceIntegrationTests.Abs
             args.add(jobJson.toURI().toString());
         }
 
-        ProcessBuilder pb = new ProcessBuilder(args);
+        LabKeyProcessBuilder pb = new LabKeyProcessBuilder(args);
         pb.directory(workDir);
 
         _log.info("Executing job in '{}': {}", pb.directory().getAbsolutePath(), String.join(" ", pb.command()));

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/preprocessing/TrimmomaticWrapper.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/preprocessing/TrimmomaticWrapper.java
@@ -21,6 +21,7 @@ import org.labkey.api.sequenceanalysis.run.AbstractCommandPipelineStep;
 import org.labkey.api.sequenceanalysis.run.AbstractCommandWrapper;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.JobRunner;
+import org.labkey.api.util.LabKeyProcessBuilder;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.sequenceanalysis.model.AdapterModel;
@@ -272,7 +273,7 @@ public class TrimmomaticWrapper extends AbstractCommandWrapper
 
     public void doTrim(List<String> params) throws PipelineJobException
     {
-        ProcessBuilder pb = getProcessBuilder(params);
+        LabKeyProcessBuilder pb = getProcessBuilder(params);
         getLogger().info(StringUtils.join(params, " "));
         pb.redirectErrorStream(false);
         Process p = null;

--- a/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/FastqcRunner.java
+++ b/SequenceAnalysis/src/org/labkey/sequenceanalysis/run/util/FastqcRunner.java
@@ -33,6 +33,7 @@ import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.Compress;
 import org.labkey.api.util.FileType;
 import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.LabKeyProcessBuilder;
 import org.labkey.api.util.Path;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.sequenceanalysis.SequenceAnalysisModule;
@@ -139,7 +140,7 @@ public class FastqcRunner
 
             _logger.info("running fastqc:");
             _logger.info(StringUtils.join(params, " "));
-            ProcessBuilder pb = new ProcessBuilder(params);
+            LabKeyProcessBuilder pb = new LabKeyProcessBuilder(params);
             pb.redirectErrorStream(true);
             pb.directory(f.getParentFile());
 


### PR DESCRIPTION
#### Rationale
We want to consistently use our own `ProcessBuilder` variant, `LabKeyProcessBuilder` to standardize the environment variables we pass to forked processes.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/7704

#### Changes
- Adopt LabKeyProcessBuilder
- Misc cleanup